### PR TITLE
fix path to go app binary

### DIFF
--- a/1.3/onbuild/Dockerfile
+++ b/1.3/onbuild/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir -p /go/src/app
 WORKDIR /go/src/app
 
 # this will ideally be built by the ONBUILD below ;)
-CMD ["/go/bin/app"]
+CMD ["/go/src/app/app"]
 
 ONBUILD COPY . /go/src/app
 ONBUILD RUN go get -d -v ./...


### PR DESCRIPTION
`go build` puts the binary in current source directory. only `go install` installs to GOBIN (`/go/bin/app`)
