### PR TITLE
Add simple "go-wrapper" script for building and running, especially to accommodate ".godir" support

### DIFF
--- a/1.2.1/Dockerfile
+++ b/1.2.1/Dockerfile
@@ -20,3 +20,5 @@ RUN mkdir -p /go/src
 ENV GOPATH /go
 ENV PATH /go/bin:$PATH
 WORKDIR /go
+
+COPY go-wrapper /usr/local/bin/

--- a/1.2.1/go-wrapper
+++ b/1.2.1/go-wrapper
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -e
+
+usage() {
+	base="$(basename "$0")"
+	cat <<EOUSAGE
+
+usage: $base command [args]
+
+This script assumes that is is run from the root of your Go package (for
+example, "/go/src/app" if your GOPATH is set to "/go").
+
+The main feature of this wrapper over the native "go" tool is that it supports
+the addition of a ".godir" file in your package directory which is a plain text
+file that is the import path your application expects (ie, it would be something
+like "github.com/jsmith/my-cool-app").  If this file is found, the current
+package is then symlinked to /go/src/<.gopath> and the commands then use that
+full import path to act on it.  This allows for applications to be universally
+cloned into a path like "/go/src/app" and then automatically built properly so
+that inter-package imports use the existing source instead of downloading it a
+second time.  This also makes the final binary have the correct name (ie,
+instead of being "/go/bin/app", it can be "/go/bin/my-cool-app"), which is why
+the "run" command exists here.
+
+Available Commands:
+
+  $base download
+  $base download -u
+    (equivalent to "go get -d [args] [godir]")
+
+  $base install
+  $base install -race
+    (equivalent to "go install [args] [godir]")
+
+  $base run
+  $base run -app -specific -arguments
+    (assumes "GOPATH/bin" is in "PATH")
+
+EOUSAGE
+}
+
+# "shift" so that "$@" becomes the remaining arguments and can be passed along to other "go" subcommands easily
+cmd="$1"
+if ! shift; then
+	usage >&2
+	exit 1
+fi
+
+dir="$(pwd -P)"
+goBin="$(basename "$dir")" # likely "app"
+
+goDir=
+if [ -f .godir ]; then
+	goDir="$(cat .godir)"
+	goPath="${GOPATH%%:*}" # this just grabs the first path listed in GOPATH, if there are multiple (which is the detection logic "go get" itself uses, too)
+	goDirPath="$goPath/src/$goDir"
+	mkdir -p "$(dirname "$goDirPath")"
+	if [ -e "$goDirPath" -a ! -L "$goDirPath" ]; then
+		echo >&2 "error: $goDirPath already exists but is unexpectedly not a symlink!"
+		exit 1
+	fi
+	ln -sfv "$dir" "$goDirPath"
+	goBin="$goPath/bin/$(basename "$goDir")"
+fi
+
+case "$cmd" in
+	download)
+		execCommand=( go get -v -d "$@" )
+		if [ "$goDir" ]; then execCommand+=( "$goDir" ); fi
+		set -x; exec "${execCommand[@]}"
+		;;
+		
+	install)
+		execCommand=( go install -v "$@" )
+		if [ "$goDir" ]; then execCommand+=( "$goDir" ); fi
+		set -x; exec "${execCommand[@]}"
+		;;
+		
+	run)
+		set -x; exec "$goBin" "$@"
+		;;
+		
+	*)
+		echo >&2 'error: unknown command:' "$cmd"
+		usage >&2
+		exit 1
+		;;
+esac

--- a/1.2.1/onbuild/Dockerfile
+++ b/1.2.1/onbuild/Dockerfile
@@ -4,8 +4,8 @@ RUN mkdir -p /go/src/app
 WORKDIR /go/src/app
 
 # this will ideally be built by the ONBUILD below ;)
-CMD ["/go/bin/app"]
+CMD ["go-wrapper", "run"]
 
 ONBUILD COPY . /go/src/app
-ONBUILD RUN go get -d -v ./...
-ONBUILD RUN go build -v ./...
+ONBUILD RUN go-wrapper download
+ONBUILD RUN go-wrapper install

--- a/1.2.2/Dockerfile
+++ b/1.2.2/Dockerfile
@@ -20,3 +20,5 @@ RUN mkdir -p /go/src
 ENV GOPATH /go
 ENV PATH /go/bin:$PATH
 WORKDIR /go
+
+COPY go-wrapper /usr/local/bin/

--- a/1.2.2/go-wrapper
+++ b/1.2.2/go-wrapper
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -e
+
+usage() {
+	base="$(basename "$0")"
+	cat <<EOUSAGE
+
+usage: $base command [args]
+
+This script assumes that is is run from the root of your Go package (for
+example, "/go/src/app" if your GOPATH is set to "/go").
+
+The main feature of this wrapper over the native "go" tool is that it supports
+the addition of a ".godir" file in your package directory which is a plain text
+file that is the import path your application expects (ie, it would be something
+like "github.com/jsmith/my-cool-app").  If this file is found, the current
+package is then symlinked to /go/src/<.gopath> and the commands then use that
+full import path to act on it.  This allows for applications to be universally
+cloned into a path like "/go/src/app" and then automatically built properly so
+that inter-package imports use the existing source instead of downloading it a
+second time.  This also makes the final binary have the correct name (ie,
+instead of being "/go/bin/app", it can be "/go/bin/my-cool-app"), which is why
+the "run" command exists here.
+
+Available Commands:
+
+  $base download
+  $base download -u
+    (equivalent to "go get -d [args] [godir]")
+
+  $base install
+  $base install -race
+    (equivalent to "go install [args] [godir]")
+
+  $base run
+  $base run -app -specific -arguments
+    (assumes "GOPATH/bin" is in "PATH")
+
+EOUSAGE
+}
+
+# "shift" so that "$@" becomes the remaining arguments and can be passed along to other "go" subcommands easily
+cmd="$1"
+if ! shift; then
+	usage >&2
+	exit 1
+fi
+
+dir="$(pwd -P)"
+goBin="$(basename "$dir")" # likely "app"
+
+goDir=
+if [ -f .godir ]; then
+	goDir="$(cat .godir)"
+	goPath="${GOPATH%%:*}" # this just grabs the first path listed in GOPATH, if there are multiple (which is the detection logic "go get" itself uses, too)
+	goDirPath="$goPath/src/$goDir"
+	mkdir -p "$(dirname "$goDirPath")"
+	if [ -e "$goDirPath" -a ! -L "$goDirPath" ]; then
+		echo >&2 "error: $goDirPath already exists but is unexpectedly not a symlink!"
+		exit 1
+	fi
+	ln -sfv "$dir" "$goDirPath"
+	goBin="$goPath/bin/$(basename "$goDir")"
+fi
+
+case "$cmd" in
+	download)
+		execCommand=( go get -v -d "$@" )
+		if [ "$goDir" ]; then execCommand+=( "$goDir" ); fi
+		set -x; exec "${execCommand[@]}"
+		;;
+		
+	install)
+		execCommand=( go install -v "$@" )
+		if [ "$goDir" ]; then execCommand+=( "$goDir" ); fi
+		set -x; exec "${execCommand[@]}"
+		;;
+		
+	run)
+		set -x; exec "$goBin" "$@"
+		;;
+		
+	*)
+		echo >&2 'error: unknown command:' "$cmd"
+		usage >&2
+		exit 1
+		;;
+esac

--- a/1.2.2/onbuild/Dockerfile
+++ b/1.2.2/onbuild/Dockerfile
@@ -4,8 +4,8 @@ RUN mkdir -p /go/src/app
 WORKDIR /go/src/app
 
 # this will ideally be built by the ONBUILD below ;)
-CMD ["/go/bin/app"]
+CMD ["go-wrapper", "run"]
 
 ONBUILD COPY . /go/src/app
-ONBUILD RUN go get -d -v ./...
-ONBUILD RUN go build -v ./...
+ONBUILD RUN go-wrapper download
+ONBUILD RUN go-wrapper install

--- a/1.2/Dockerfile
+++ b/1.2/Dockerfile
@@ -20,3 +20,5 @@ RUN mkdir -p /go/src
 ENV GOPATH /go
 ENV PATH /go/bin:$PATH
 WORKDIR /go
+
+COPY go-wrapper /usr/local/bin/

--- a/1.2/go-wrapper
+++ b/1.2/go-wrapper
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -e
+
+usage() {
+	base="$(basename "$0")"
+	cat <<EOUSAGE
+
+usage: $base command [args]
+
+This script assumes that is is run from the root of your Go package (for
+example, "/go/src/app" if your GOPATH is set to "/go").
+
+The main feature of this wrapper over the native "go" tool is that it supports
+the addition of a ".godir" file in your package directory which is a plain text
+file that is the import path your application expects (ie, it would be something
+like "github.com/jsmith/my-cool-app").  If this file is found, the current
+package is then symlinked to /go/src/<.gopath> and the commands then use that
+full import path to act on it.  This allows for applications to be universally
+cloned into a path like "/go/src/app" and then automatically built properly so
+that inter-package imports use the existing source instead of downloading it a
+second time.  This also makes the final binary have the correct name (ie,
+instead of being "/go/bin/app", it can be "/go/bin/my-cool-app"), which is why
+the "run" command exists here.
+
+Available Commands:
+
+  $base download
+  $base download -u
+    (equivalent to "go get -d [args] [godir]")
+
+  $base install
+  $base install -race
+    (equivalent to "go install [args] [godir]")
+
+  $base run
+  $base run -app -specific -arguments
+    (assumes "GOPATH/bin" is in "PATH")
+
+EOUSAGE
+}
+
+# "shift" so that "$@" becomes the remaining arguments and can be passed along to other "go" subcommands easily
+cmd="$1"
+if ! shift; then
+	usage >&2
+	exit 1
+fi
+
+dir="$(pwd -P)"
+goBin="$(basename "$dir")" # likely "app"
+
+goDir=
+if [ -f .godir ]; then
+	goDir="$(cat .godir)"
+	goPath="${GOPATH%%:*}" # this just grabs the first path listed in GOPATH, if there are multiple (which is the detection logic "go get" itself uses, too)
+	goDirPath="$goPath/src/$goDir"
+	mkdir -p "$(dirname "$goDirPath")"
+	if [ -e "$goDirPath" -a ! -L "$goDirPath" ]; then
+		echo >&2 "error: $goDirPath already exists but is unexpectedly not a symlink!"
+		exit 1
+	fi
+	ln -sfv "$dir" "$goDirPath"
+	goBin="$goPath/bin/$(basename "$goDir")"
+fi
+
+case "$cmd" in
+	download)
+		execCommand=( go get -v -d "$@" )
+		if [ "$goDir" ]; then execCommand+=( "$goDir" ); fi
+		set -x; exec "${execCommand[@]}"
+		;;
+		
+	install)
+		execCommand=( go install -v "$@" )
+		if [ "$goDir" ]; then execCommand+=( "$goDir" ); fi
+		set -x; exec "${execCommand[@]}"
+		;;
+		
+	run)
+		set -x; exec "$goBin" "$@"
+		;;
+		
+	*)
+		echo >&2 'error: unknown command:' "$cmd"
+		usage >&2
+		exit 1
+		;;
+esac

--- a/1.2/onbuild/Dockerfile
+++ b/1.2/onbuild/Dockerfile
@@ -4,8 +4,8 @@ RUN mkdir -p /go/src/app
 WORKDIR /go/src/app
 
 # this will ideally be built by the ONBUILD below ;)
-CMD ["/go/bin/app"]
+CMD ["go-wrapper", "run"]
 
 ONBUILD COPY . /go/src/app
-ONBUILD RUN go get -d -v ./...
-ONBUILD RUN go build -v ./...
+ONBUILD RUN go-wrapper download
+ONBUILD RUN go-wrapper install

--- a/1.3.1/Dockerfile
+++ b/1.3.1/Dockerfile
@@ -20,3 +20,5 @@ RUN mkdir -p /go/src
 ENV GOPATH /go
 ENV PATH /go/bin:$PATH
 WORKDIR /go
+
+COPY go-wrapper /usr/local/bin/

--- a/1.3.1/go-wrapper
+++ b/1.3.1/go-wrapper
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -e
+
+usage() {
+	base="$(basename "$0")"
+	cat <<EOUSAGE
+
+usage: $base command [args]
+
+This script assumes that is is run from the root of your Go package (for
+example, "/go/src/app" if your GOPATH is set to "/go").
+
+The main feature of this wrapper over the native "go" tool is that it supports
+the addition of a ".godir" file in your package directory which is a plain text
+file that is the import path your application expects (ie, it would be something
+like "github.com/jsmith/my-cool-app").  If this file is found, the current
+package is then symlinked to /go/src/<.gopath> and the commands then use that
+full import path to act on it.  This allows for applications to be universally
+cloned into a path like "/go/src/app" and then automatically built properly so
+that inter-package imports use the existing source instead of downloading it a
+second time.  This also makes the final binary have the correct name (ie,
+instead of being "/go/bin/app", it can be "/go/bin/my-cool-app"), which is why
+the "run" command exists here.
+
+Available Commands:
+
+  $base download
+  $base download -u
+    (equivalent to "go get -d [args] [godir]")
+
+  $base install
+  $base install -race
+    (equivalent to "go install [args] [godir]")
+
+  $base run
+  $base run -app -specific -arguments
+    (assumes "GOPATH/bin" is in "PATH")
+
+EOUSAGE
+}
+
+# "shift" so that "$@" becomes the remaining arguments and can be passed along to other "go" subcommands easily
+cmd="$1"
+if ! shift; then
+	usage >&2
+	exit 1
+fi
+
+dir="$(pwd -P)"
+goBin="$(basename "$dir")" # likely "app"
+
+goDir=
+if [ -f .godir ]; then
+	goDir="$(cat .godir)"
+	goPath="${GOPATH%%:*}" # this just grabs the first path listed in GOPATH, if there are multiple (which is the detection logic "go get" itself uses, too)
+	goDirPath="$goPath/src/$goDir"
+	mkdir -p "$(dirname "$goDirPath")"
+	if [ -e "$goDirPath" -a ! -L "$goDirPath" ]; then
+		echo >&2 "error: $goDirPath already exists but is unexpectedly not a symlink!"
+		exit 1
+	fi
+	ln -sfv "$dir" "$goDirPath"
+	goBin="$goPath/bin/$(basename "$goDir")"
+fi
+
+case "$cmd" in
+	download)
+		execCommand=( go get -v -d "$@" )
+		if [ "$goDir" ]; then execCommand+=( "$goDir" ); fi
+		set -x; exec "${execCommand[@]}"
+		;;
+		
+	install)
+		execCommand=( go install -v "$@" )
+		if [ "$goDir" ]; then execCommand+=( "$goDir" ); fi
+		set -x; exec "${execCommand[@]}"
+		;;
+		
+	run)
+		set -x; exec "$goBin" "$@"
+		;;
+		
+	*)
+		echo >&2 'error: unknown command:' "$cmd"
+		usage >&2
+		exit 1
+		;;
+esac

--- a/1.3.1/onbuild/Dockerfile
+++ b/1.3.1/onbuild/Dockerfile
@@ -4,8 +4,8 @@ RUN mkdir -p /go/src/app
 WORKDIR /go/src/app
 
 # this will ideally be built by the ONBUILD below ;)
-CMD ["/go/bin/app"]
+CMD ["go-wrapper", "run"]
 
 ONBUILD COPY . /go/src/app
-ONBUILD RUN go get -d -v ./...
-ONBUILD RUN go build -v ./...
+ONBUILD RUN go-wrapper download
+ONBUILD RUN go-wrapper install

--- a/1.3/Dockerfile
+++ b/1.3/Dockerfile
@@ -20,3 +20,5 @@ RUN mkdir -p /go/src
 ENV GOPATH /go
 ENV PATH /go/bin:$PATH
 WORKDIR /go
+
+COPY go-wrapper /usr/local/bin/

--- a/1.3/go-wrapper
+++ b/1.3/go-wrapper
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -e
+
+usage() {
+	base="$(basename "$0")"
+	cat <<EOUSAGE
+
+usage: $base command [args]
+
+This script assumes that is is run from the root of your Go package (for
+example, "/go/src/app" if your GOPATH is set to "/go").
+
+The main feature of this wrapper over the native "go" tool is that it supports
+the addition of a ".godir" file in your package directory which is a plain text
+file that is the import path your application expects (ie, it would be something
+like "github.com/jsmith/my-cool-app").  If this file is found, the current
+package is then symlinked to /go/src/<.gopath> and the commands then use that
+full import path to act on it.  This allows for applications to be universally
+cloned into a path like "/go/src/app" and then automatically built properly so
+that inter-package imports use the existing source instead of downloading it a
+second time.  This also makes the final binary have the correct name (ie,
+instead of being "/go/bin/app", it can be "/go/bin/my-cool-app"), which is why
+the "run" command exists here.
+
+Available Commands:
+
+  $base download
+  $base download -u
+    (equivalent to "go get -d [args] [godir]")
+
+  $base install
+  $base install -race
+    (equivalent to "go install [args] [godir]")
+
+  $base run
+  $base run -app -specific -arguments
+    (assumes "GOPATH/bin" is in "PATH")
+
+EOUSAGE
+}
+
+# "shift" so that "$@" becomes the remaining arguments and can be passed along to other "go" subcommands easily
+cmd="$1"
+if ! shift; then
+	usage >&2
+	exit 1
+fi
+
+dir="$(pwd -P)"
+goBin="$(basename "$dir")" # likely "app"
+
+goDir=
+if [ -f .godir ]; then
+	goDir="$(cat .godir)"
+	goPath="${GOPATH%%:*}" # this just grabs the first path listed in GOPATH, if there are multiple (which is the detection logic "go get" itself uses, too)
+	goDirPath="$goPath/src/$goDir"
+	mkdir -p "$(dirname "$goDirPath")"
+	if [ -e "$goDirPath" -a ! -L "$goDirPath" ]; then
+		echo >&2 "error: $goDirPath already exists but is unexpectedly not a symlink!"
+		exit 1
+	fi
+	ln -sfv "$dir" "$goDirPath"
+	goBin="$goPath/bin/$(basename "$goDir")"
+fi
+
+case "$cmd" in
+	download)
+		execCommand=( go get -v -d "$@" )
+		if [ "$goDir" ]; then execCommand+=( "$goDir" ); fi
+		set -x; exec "${execCommand[@]}"
+		;;
+		
+	install)
+		execCommand=( go install -v "$@" )
+		if [ "$goDir" ]; then execCommand+=( "$goDir" ); fi
+		set -x; exec "${execCommand[@]}"
+		;;
+		
+	run)
+		set -x; exec "$goBin" "$@"
+		;;
+		
+	*)
+		echo >&2 'error: unknown command:' "$cmd"
+		usage >&2
+		exit 1
+		;;
+esac

--- a/1.3/onbuild/Dockerfile
+++ b/1.3/onbuild/Dockerfile
@@ -4,8 +4,8 @@ RUN mkdir -p /go/src/app
 WORKDIR /go/src/app
 
 # this will ideally be built by the ONBUILD below ;)
-CMD ["/go/bin/app"]
+CMD ["go-wrapper", "run"]
 
 ONBUILD COPY . /go/src/app
-ONBUILD RUN go get -d -v ./...
-ONBUILD RUN go build -v ./...
+ONBUILD RUN go-wrapper download
+ONBUILD RUN go-wrapper install

--- a/go-wrapper
+++ b/go-wrapper
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -e
+
+usage() {
+	base="$(basename "$0")"
+	cat <<EOUSAGE
+
+usage: $base command [args]
+
+This script assumes that is is run from the root of your Go package (for
+example, "/go/src/app" if your GOPATH is set to "/go").
+
+The main feature of this wrapper over the native "go" tool is that it supports
+the addition of a ".godir" file in your package directory which is a plain text
+file that is the import path your application expects (ie, it would be something
+like "github.com/jsmith/my-cool-app").  If this file is found, the current
+package is then symlinked to /go/src/<.gopath> and the commands then use that
+full import path to act on it.  This allows for applications to be universally
+cloned into a path like "/go/src/app" and then automatically built properly so
+that inter-package imports use the existing source instead of downloading it a
+second time.  This also makes the final binary have the correct name (ie,
+instead of being "/go/bin/app", it can be "/go/bin/my-cool-app"), which is why
+the "run" command exists here.
+
+Available Commands:
+
+  $base download
+  $base download -u
+    (equivalent to "go get -d [args] [godir]")
+
+  $base install
+  $base install -race
+    (equivalent to "go install [args] [godir]")
+
+  $base run
+  $base run -app -specific -arguments
+    (assumes "GOPATH/bin" is in "PATH")
+
+EOUSAGE
+}
+
+# "shift" so that "$@" becomes the remaining arguments and can be passed along to other "go" subcommands easily
+cmd="$1"
+if ! shift; then
+	usage >&2
+	exit 1
+fi
+
+dir="$(pwd -P)"
+goBin="$(basename "$dir")" # likely "app"
+
+goDir=
+if [ -f .godir ]; then
+	goDir="$(cat .godir)"
+	goPath="${GOPATH%%:*}" # this just grabs the first path listed in GOPATH, if there are multiple (which is the detection logic "go get" itself uses, too)
+	goDirPath="$goPath/src/$goDir"
+	mkdir -p "$(dirname "$goDirPath")"
+	if [ -e "$goDirPath" -a ! -L "$goDirPath" ]; then
+		echo >&2 "error: $goDirPath already exists but is unexpectedly not a symlink!"
+		exit 1
+	fi
+	ln -sfv "$dir" "$goDirPath"
+	goBin="$goPath/bin/$(basename "$goDir")"
+fi
+
+case "$cmd" in
+	download)
+		execCommand=( go get -v -d "$@" )
+		if [ "$goDir" ]; then execCommand+=( "$goDir" ); fi
+		set -x; exec "${execCommand[@]}"
+		;;
+		
+	install)
+		execCommand=( go install -v "$@" )
+		if [ "$goDir" ]; then execCommand+=( "$goDir" ); fi
+		set -x; exec "${execCommand[@]}"
+		;;
+		
+	run)
+		set -x; exec "$goBin" "$@"
+		;;
+		
+	*)
+		echo >&2 'error: unknown command:' "$cmd"
+		usage >&2
+		exit 1
+		;;
+esac

--- a/update.sh
+++ b/update.sh
@@ -16,5 +16,6 @@ for version in "${versions[@]}"; do
 		set -x
 		sed -ri 's/^(ENV GOLANG_VERSION) .*/\1 '"$fullVersion"'/' "$version/Dockerfile"
 		sed -ri 's/^(FROM golang):.*/\1:'"$fullVersion"'/' "$version/"*"/Dockerfile"
+		cp go-wrapper "$version/"
 	)
 done


### PR DESCRIPTION
Fixes #4
Fixes #9

Also, `update.sh` will make sure it's properly copied into each version subfolder, like we've done with other official images.
