### PR TITLE
Refactor `RUN bash -xec` to just use `RUN`

### DIFF
--- a/1.3.1/cross/Dockerfile
+++ b/1.3.1/cross/Dockerfile
@@ -21,9 +21,8 @@ ENV GOLANG_CROSSPLATFORMS \
 # (set an explicit GOARM of 5 for maximum ARM compatibility)
 ENV GOARM 5
 
-WORKDIR /usr/src/go/src
-
-RUN for platform in $GOLANG_CROSSPLATFORMS; do \
+RUN cd /usr/src/go/src && \
+	for platform in $GOLANG_CROSSPLATFORMS; do \
 		GOOS=${platform%/*} \
 		GOARCH=${platform##*/} \
 		./make.bash --no-clean 2>&1 || exit $?; \


### PR DESCRIPTION
This changes the `cd /usr/src/go/src` to use `WORKDIR` and `-x` flag to `|| exit $?`. I've tried this change on my machine, and [it seams fine](https://gist.github.com/maxnordlund/cb2f85901679cc9726fc). Fair warning the log is ~7600 lines long.
