### PR TITLE
Remove android/arm from 1.4/cross since it's nontrivial to get the -marm compiler backend for it

### DIFF
--- a/1.4/cross/Dockerfile
+++ b/1.4/cross/Dockerfile
@@ -5,7 +5,6 @@ FROM golang:1.4rc1
 # and canonically, see defs_OS_ARCH.h files in src/runtime
 #   https://code.google.com/p/go/source/browse?name=go1.4beta1#hg%2Fsrc%2Fruntime
 ENV GOLANG_CROSSPLATFORMS \
-	android/arm \
 	darwin/386 darwin/amd64 \
 	dragonfly/386 dragonfly/amd64 \
 	freebsd/386 freebsd/amd64 freebsd/arm \
@@ -16,6 +15,9 @@ ENV GOLANG_CROSSPLATFORMS \
 	plan9/386 plan9/amd64 \
 	solaris/amd64 \
 	windows/386 windows/amd64
+
+# TODO gcc: error: unrecognized command line option '-marm'
+#	android/arm \
 
 # ls src/runtime/defs_*_*.h | sed -r 's!^.*/defs_([^_]+)_([^_]+)[.]h$!\1/\2!'
 


### PR DESCRIPTION
I think we can safely revisit this later.  I'm really keen on getting this working, since it's awesome, but getting over that compiler hump is going to be fun.

For the curious, I was playing with variations on the following to get this to work:

``` Dockerfile
RUN echo 'deb http://http.debian.net/debian sid main' > /etc/apt/sources.list.d/sid.list \
    && dpkg --add-architecture armel \
    && apt-get update && apt-get install -y gcc-arm-linux-gnueabi \
    && rm -rf /var/lib/apt/lists/* \
    && rm /etc/apt/sources.list.d/sid.list
```

(see also https://packages.debian.org/sid/gcc-arm-linux-gnueabi)
