### PR TITLE
Remove set -x to prevent spamming stderr

### DIFF
--- a/go-wrapper
+++ b/go-wrapper
@@ -74,17 +74,17 @@ case "$cmd" in
 	download)
 		execCommand=( go get -v -d "$@" )
 		if [ "$goDir" ]; then execCommand+=( "$goDir" ); fi
-		set -x; exec "${execCommand[@]}"
+		exec "${execCommand[@]}"
 		;;
 		
 	install)
 		execCommand=( go install -v "$@" )
 		if [ "$goDir" ]; then execCommand+=( "$goDir" ); fi
-		set -x; exec "${execCommand[@]}"
+		exec "${execCommand[@]}"
 		;;
 		
 	run)
-		set -x; exec "$goBin" "$@"
+		exec "$goBin" "$@"
 		;;
 		
 	*)


### PR DESCRIPTION
In our environment, we assume that everything coming from a docker app written to stderr is an error message. The set -x in the docker base image means we get a spurious "+ exec app" message on app startup.