### PR TITLE
Add the GOROOT_BOOTSTRAP env var to the image so that we can build go 1.5

### DIFF
--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -21,3 +21,5 @@ ENV PATH /go/bin:$PATH
 WORKDIR /go
 
 COPY go-wrapper /usr/local/bin/
+
+ENV GOROOT_BOOTSTRAP /usr/src/go


### PR DESCRIPTION
see https://docs.google.com/document/d/1OaatvGhEAq7VseQ9kkavxKNAfepWy2yhPUBs96FGV28/edit

Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

I was tooling around on my vacation, and was saddened to find our golang image couldn't build golang master.