### PR TITLE
verify the golang tarball against it's expected sha1

### DIFF
--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -7,17 +7,19 @@ RUN apt-get update && apt-get install -y \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GOLANG_VERSION 1.4.2
+ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz
+ENV GOLANG_DOWNLOAD_SHA1 460caac03379f746c473814a65223397e9c9a2f6
 
-RUN curl -sSL https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz \
-		| tar -v -C /usr/src -xz
+RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
+	&& echo "$GOLANG_DOWNLOAD_SHA1  golang.tar.gz" | sha1sum -c - \
+	&& tar -C /usr/src -xzf golang.tar.gz \
+	&& rm golang.tar.gz \
+	&& cd /usr/src/go/src && ./make.bash --no-clean 2>&1
 
-RUN cd /usr/src/go/src && ./make.bash --no-clean 2>&1
-
-ENV PATH /usr/src/go/bin:$PATH
-
-RUN mkdir -p /go/src /go/bin && chmod -R 777 /go
 ENV GOPATH /go
-ENV PATH /go/bin:$PATH
-WORKDIR /go
+ENV PATH $GOPATH/bin:/usr/src/go/bin:$PATH
+
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH
 
 COPY go-wrapper /usr/local/bin/

--- a/1.4/wheezy/Dockerfile
+++ b/1.4/wheezy/Dockerfile
@@ -7,17 +7,19 @@ RUN apt-get update && apt-get install -y \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GOLANG_VERSION 1.4.2
+ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz
+ENV GOLANG_DOWNLOAD_SHA1 460caac03379f746c473814a65223397e9c9a2f6
 
-RUN curl -sSL https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz \
-		| tar -v -C /usr/src -xz
+RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
+	&& echo "$GOLANG_DOWNLOAD_SHA1  golang.tar.gz" | sha1sum -c - \
+	&& tar -C /usr/src -xzf golang.tar.gz \
+	&& rm golang.tar.gz \
+	&& cd /usr/src/go/src && ./make.bash --no-clean 2>&1
 
-RUN cd /usr/src/go/src && ./make.bash --no-clean 2>&1
-
-ENV PATH /usr/src/go/bin:$PATH
-
-RUN mkdir -p /go/src /go/bin && chmod -R 777 /go
 ENV GOPATH /go
-ENV PATH /go/bin:$PATH
-WORKDIR /go
+ENV PATH $GOPATH/bin:/usr/src/go/bin:$PATH
+
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH
 
 COPY go-wrapper /usr/local/bin/

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -6,12 +6,14 @@ RUN apt-get update && apt-get install -y \
 		--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_GOOS linux
-ENV GOLANG_GOARCH amd64
 ENV GOLANG_VERSION 1.5
+ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
+ENV GOLANG_DOWNLOAD_SHA1 5817fa4b2252afdb02e11e8b9dc1d9173ef3bd5a
 
-RUN curl -sSL https://golang.org/dl/go$GOLANG_VERSION.$GOLANG_GOOS-$GOLANG_GOARCH.tar.gz \
-		| tar -v -C /usr/local -xz
+RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
+	&& echo "$GOLANG_DOWNLOAD_SHA1  golang.tar.gz" | sha1sum -c - \
+	&& tar -C /usr/local -xzf golang.tar.gz \
+	&& rm golang.tar.gz
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH


### PR DESCRIPTION
```
$ docker build --rm -t golang .
Sending build context to Docker daemon 7.168 kB
Step 0 : FROM buildpack-deps:jessie-scm
 ---> 607e965985c1
Step 1 : RUN apt-get update && apt-get install -y 		gcc libc6-dev make 		--no-install-recommends 	&& rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> 0f5121dd42a6
Step 2 : ENV GOLANG_VERSION 1.5
 ---> Using cache
 ---> 848707a3bad7
Step 3 : ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
 ---> Using cache
 ---> ad6927e0d810
Step 4 : ENV GOLANG_DOWNLOAD_SHA1 5817fa4b2252afdb02e11e8b9dc1d9173ef3bd5a
 ---> Using cache
 ---> 86a6f69b4e93
Step 5 : RUN mkdir -p /usr/src/golang 	&& curl -sSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz 	&& echo "$GOLANG_DOWNLOAD_SHA1  golang.tar.gz" | sha1sum -c - 	&& tar -v -C /usr/local -xzf golang.tar.gz 	&& rm -r /usr/src/golang
 ---> Using cache
 ---> 747b36b4eaca
Step 6 : ENV GOPATH /go
 ---> Using cache
 ---> 37f7914c54e4
Step 7 : ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 ---> Using cache
 ---> 136191ef5c13
Step 8 : RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 ---> Using cache
 ---> e592541eddd9
Step 9 : WORKDIR $GOPATH
 ---> Using cache
 ---> 5d574e30aff0
Step 10 : COPY go-wrapper /usr/local/bin/
 ---> Using cache
 ---> 64150e376c56
Successfully built 64150e376c56
$ docker run --rm -it golang go version
go version go1.5 linux/amd64
```

Fixes #47

:tada: