### PR TITLE
Add git to Alpine images

### DIFF
--- a/1.5/alpine/Dockerfile
+++ b/1.5/alpine/Dockerfile
@@ -13,6 +13,7 @@ RUN set -ex \
 		bash \
 		ca-certificates \
 		gcc \
+		git \
 		musl-dev \
 		openssl \
 	\

--- a/1.6/alpine/Dockerfile
+++ b/1.6/alpine/Dockerfile
@@ -13,6 +13,7 @@ RUN set -ex \
 		bash \
 		ca-certificates \
 		gcc \
+		git \
 		musl-dev \
 		openssl \
 	\


### PR DESCRIPTION
This enables the use of `go get` inside the Alpine images without first installing git.