### PR TITLE
add -fno-PIC when using external linker on alpine

### DIFF
--- a/1.6/alpine/Dockerfile
+++ b/1.6/alpine/Dockerfile
@@ -8,6 +8,9 @@ ENV GOLANG_BOOTSTRAP_VERSION 1.4.3
 ENV GOLANG_BOOTSTRAP_URL https://golang.org/dl/go$GOLANG_BOOTSTRAP_VERSION.src.tar.gz
 ENV GOLANG_BOOTSTRAP_SHA1 486db10dc571a55c8d795365070f66d343458c48
 
+# https://golang.org/issue/14851
+COPY no-pic.patch /
+
 RUN set -ex \
 	&& apk add --no-cache --virtual .build-deps \
 		bash \
@@ -30,9 +33,10 @@ RUN set -ex \
 	&& tar -C /usr/local -xzf golang.tar.gz \
 	&& rm golang.tar.gz \
 	&& cd /usr/local/go/src \
+	&& patch -p2 -i /no-pic.patch \
 	&& ./make.bash \
 	\
-	&& rm -rf /usr/local/bootstrap /usr/local/go/pkg/bootstrap \
+	&& rm -rf /usr/local/bootstrap /usr/local/go/pkg/bootstrap /*.patch \
 	&& apk del .build-deps
 
 ENV GOPATH /go

--- a/1.6/alpine/no-pic.patch
+++ b/1.6/alpine/no-pic.patch
@@ -1,0 +1,16 @@
+diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
+index 8ccbec9dd634..4e96bfadc260 100644
+--- a/src/cmd/link/internal/ld/lib.go
++++ b/src/cmd/link/internal/ld/lib.go
+@@ -1194,6 +1194,11 @@ func hostlink() {
+ 		argv = append(argv, peimporteddlls()...)
+ 	}
+ 
++	// The Go linker does not currently support building PIE
++	// executables when using the external linker. See:
++	// https://github.com/golang/go/issues/6940
++	argv = append(argv, "-fno-PIC")
++
+ 	if Debug['v'] != 0 {
+ 		fmt.Fprintf(&Bso, "host link:")
+ 		for _, v := range argv {


### PR DESCRIPTION
The Alpine toolchain enables PIE by default. Since the go linker does
not (yet) support PIE we need to explicitly disable it on Alpine.

This is a workaround for https://github.com/golang/go/issues/14851