### PR TITLE
Add Windows Dockerfile

### DIFF
--- a/1.6/Dockerfile.windows
+++ b/1.6/Dockerfile.windows
@@ -4,6 +4,7 @@ ENV GOLANG_VERSION 1.6.1
 ENV GOLANG_DOWNLOAD_URL "https://golang.org/dl/go$GOLANG_VERSION.windows-amd64.zip"
 
 RUN powershell -Command \
+	$ErrorActionPreference = 'Stop'; \
 	(New-Object System.Net.WebClient).DownloadFile('%GOLANG_DOWNLOAD_URL%', 'go.zip') ; \
 	Expand-Archive go.zip -DestinationPath c:\\ ; \
 	Remove-Item go.zip -Force

--- a/1.6/Dockerfile.windows
+++ b/1.6/Dockerfile.windows
@@ -1,0 +1,12 @@
+FROM windowsservercore
+
+ENV GOLANG_VERSION 1.6.1
+ENV GOLANG_DOWNLOAD_URL "https://golang.org/dl/go$GOLANG_VERSION.windows-amd64.zip"
+
+RUN powershell -Command \
+	(New-Object System.Net.WebClient).DownloadFile('%GOLANG_DOWNLOAD_URL%', 'go.zip') ; \
+	Expand-Archive go.zip -DestinationPath c:\\ ; \
+	Remove-Item go.zip -Force
+
+RUN setx /M PATH "C:\go\bin;%PATH%" && \
+	setx /M GOPATH "C:\go"

--- a/1.6/Dockerfile.windows
+++ b/1.6/Dockerfile.windows
@@ -2,10 +2,12 @@ FROM windowsservercore
 
 ENV GOLANG_VERSION 1.6.1
 ENV GOLANG_DOWNLOAD_URL "https://golang.org/dl/go$GOLANG_VERSION.windows-amd64.zip"
+ENV GOLANG_DOWNLOAD_SHA256 "1505afbcc5f71598c6ffd2a56ad550e4e8728c05649e9085f725e38d6b5a0fb8"
 
 RUN powershell -Command \
 	$ErrorActionPreference = 'Stop'; \
 	(New-Object System.Net.WebClient).DownloadFile('%GOLANG_DOWNLOAD_URL%', 'go.zip') ; \
+	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $env:GOLANG_DOWNLOAD_SHA256) {exit 1} ; \
 	Expand-Archive go.zip -DestinationPath c:\\ ; \
 	Remove-Item go.zip -Force
 


### PR DESCRIPTION
This is a canary PR to explore what getting Windows image into the official library would look like.

We'd want to have both `windowsservercore` and `nanoserver` derived images, maybe they should be in subfolders like alpine.

/cc @wol4max @tianon @taylorb-microsoft @StefanScherer @jstarks @jhowardmsft