### PR TITLE
Convert "generate-stackbrew-library.sh" to output the new 2822-based format

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,42 +1,88 @@
 #!/bin/bash
-set -e
+set -eu
 
 declare -A aliases
 aliases=(
 	[1.6]='1 latest'
 )
 
+self="$(basename "$BASH_SOURCE")"
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 versions=( */ )
 versions=( "${versions[@]%/}" )
-url='git://github.com/docker-library/golang'
 
-echo '# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)'
-echo '# maintainer: Johan Euphrosine <proppy@google.com> (@proppy)'
+# get the most recent commit which modified any of "$@"
+fileCommit() {
+	git log -1 --format='format:%H' HEAD -- "$@"
+}
+
+# get the most recent commit which modified "$1/Dockerfile" or any file COPY'd from "$1/Dockerfile"
+dirCommit() {
+	local dir="$1"; shift
+	(
+		cd "$dir"
+		fileCommit \
+			Dockerfile \
+			$(git show HEAD:./Dockerfile | awk '
+				toupper($1) == "COPY" {
+					for (i = 2; i < NF; i++) {
+						print $i
+					}
+				}
+			')
+	)
+}
+
+cat <<-EOH
+# this file is generated via https://github.com/docker-library/golang/blob/$(fileCommit "$self")/$self
+
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
+             Johan Euphrosine <proppy@google.com> (@proppy)
+GitRepo: https://github.com/docker-library/golang.git
+
+EOH
+
+# prints "$2$1$3$1...$N"
+join() {
+	local sep="$1"; shift
+	local out; printf -v out "${sep//%/%%}%s" "$@"
+	echo "${out#$sep}"
+}
 
 for version in "${versions[@]}"; do
-	commit="$(cd "$version" && git log -1 --format='format:%H' -- Dockerfile $(awk 'toupper($1) == "COPY" { for (i = 2; i < NF; i++) { print $i } }' Dockerfile))"
-	fullVersion="$(grep -m1 'ENV GOLANG_VERSION ' "$version/Dockerfile" | cut -d' ' -f3)"
+	commit="$(dirCommit "$version")"
+
+	fullVersion="$(git show "$commit":"$version/Dockerfile" | awk '$1 == "ENV" && $2 == "GOLANG_VERSION" { print $3; exit }')"
 	[[ "$fullVersion" == *.*[^0-9]* ]] || fullVersion+='.0'
-	versionAliases=( $fullVersion $version ${aliases[$version]} )
-	
+
+	versionAliases=(
+		$fullVersion
+		$version
+		${aliases[$version]:-}
+	)
+
 	echo
-	for va in "${versionAliases[@]}"; do
-		echo "$va: ${url}@${commit} $version"
-	done
-	
+	cat <<-EOE
+		Tags: $(join ', ' "${versionAliases[@]}")
+		GitCommit: $commit
+		Directory: $version
+	EOE
+
 	for variant in onbuild cross wheezy alpine; do
 		[ -f "$version/$variant/Dockerfile" ] || continue
-		commit="$(cd "$version/$variant" && git log -1 --format='format:%H' -- Dockerfile $(awk 'toupper($1) == "COPY" { for (i = 2; i < NF; i++) { print $i } }' Dockerfile))"
+
+		commit="$(dirCommit "$version/$variant")"
+
+		variantAliases=( "${versionAliases[@]/%/-$variant}" )
+		variantAliases=( "${variantAliases[@]//latest-/}" )
+
 		echo
-		for va in "${versionAliases[@]}"; do
-			if [ "$va" = 'latest' ]; then
-				va="$variant"
-			else
-				va="$va-$variant"
-			fi
-			echo "$va: ${url}@${commit} $version/$variant"
-		done
+		cat <<-EOE
+			Tags: $(join ', ' "${variantAliases[@]}")
+			GitCommit: $commit
+			Directory: $version/$variant
+		EOE
 	done
 done


### PR DESCRIPTION
cc @md5 (relevant to your interests)

It's not Perl, but I think it's easy enough to read anyways (and even in Perl, we'll have the same copy-pasta between repos that we'll have with this).

Once we've got this straw man somewhere we're happy with, I'll be slowly considering converting more repos over with similar PRs.