### PR TITLE
add root certificates to Alpine images

### DIFF
--- a/1.5/alpine/Dockerfile
+++ b/1.5/alpine/Dockerfile
@@ -1,11 +1,12 @@
 FROM alpine:3.4
 
+RUN apk add --no-cache ca-certificates
+
 ENV GOLANG_VERSION 1.5.4
 ENV GOLANG_SRC_URL https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz
 ENV GOLANG_SRC_SHA256 002acabce7ddc140d0d55891f9d4fcfbdd806b9332fb8b110c91bc91afb0bc93
 
 RUN set -ex \
-	&& apk add --no-cache ca-certificates \
 	&& apk add --no-cache --virtual .build-deps \
 		bash \
 		gcc \

--- a/1.5/alpine/Dockerfile
+++ b/1.5/alpine/Dockerfile
@@ -5,9 +5,9 @@ ENV GOLANG_SRC_URL https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz
 ENV GOLANG_SRC_SHA256 002acabce7ddc140d0d55891f9d4fcfbdd806b9332fb8b110c91bc91afb0bc93
 
 RUN set -ex \
+	&& apk add --no-cache ca-certificates \
 	&& apk add --no-cache --virtual .build-deps \
 		bash \
-		ca-certificates \
 		gcc \
 		musl-dev \
 		openssl \

--- a/1.6/alpine/Dockerfile
+++ b/1.6/alpine/Dockerfile
@@ -8,9 +8,9 @@ ENV GOLANG_SRC_SHA256 787b0b750d037016a30c6ed05a8a70a91b2e9db4bd9b1a2453aa502a63
 COPY no-pic.patch /
 
 RUN set -ex \
+	&& apk add --no-cache ca-certificates \
 	&& apk add --no-cache --virtual .build-deps \
 		bash \
-		ca-certificates \
 		gcc \
 		musl-dev \
 		openssl \

--- a/1.6/alpine/Dockerfile
+++ b/1.6/alpine/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.4
 
+RUN apk add --no-cache ca-certificates
+
 ENV GOLANG_VERSION 1.6.2
 ENV GOLANG_SRC_URL https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz
 ENV GOLANG_SRC_SHA256 787b0b750d037016a30c6ed05a8a70a91b2e9db4bd9b1a2453aa502a63f1bccc
@@ -8,7 +10,6 @@ ENV GOLANG_SRC_SHA256 787b0b750d037016a30c6ed05a8a70a91b2e9db4bd9b1a2453aa502a63
 COPY no-pic.patch /
 
 RUN set -ex \
-	&& apk add --no-cache ca-certificates \
 	&& apk add --no-cache --virtual .build-deps \
 		bash \
 		gcc \

--- a/1.7/alpine/Dockerfile
+++ b/1.7/alpine/Dockerfile
@@ -8,9 +8,9 @@ ENV GOLANG_SRC_SHA256 88840e78905bdff7c8e408385182b4f77e8bdd062cac5c0c6382630588
 COPY no-pic.patch /
 
 RUN set -ex \
+	&& apk add --no-cache ca-certificates \
 	&& apk add --no-cache --virtual .build-deps \
 		bash \
-		ca-certificates \
 		gcc \
 		musl-dev \
 		openssl \

--- a/1.7/alpine/Dockerfile
+++ b/1.7/alpine/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.4
 
+RUN apk add --no-cache ca-certificates
+
 ENV GOLANG_VERSION 1.7beta2
 ENV GOLANG_SRC_URL https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz
 ENV GOLANG_SRC_SHA256 88840e78905bdff7c8e408385182b4f77e8bdd062cac5c0c6382630588d426c7
@@ -8,7 +10,6 @@ ENV GOLANG_SRC_SHA256 88840e78905bdff7c8e408385182b4f77e8bdd062cac5c0c6382630588
 COPY no-pic.patch /
 
 RUN set -ex \
-	&& apk add --no-cache ca-certificates \
 	&& apk add --no-cache --virtual .build-deps \
 		bash \
 		gcc \


### PR DESCRIPTION
Fixes #96 (and the duplicate #97).

This allows Go's HTTP library to make HTTPS client connections with secure certificate validation. Without this change, `net/http` in these images return the error `"x509: failed to load system roots and no roots provided"`.

This adds 0.6MB to the image (as measured with docker history).