### PR TITLE
Update to 1.7rc1

### DIFF
--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -8,9 +8,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		make \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION 1.7beta2
+ENV GOLANG_VERSION 1.7rc1
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 688f895b51def9e065fb2610ff91afcb2b0d9637233b74130c8ca331d35d5ca5
+ENV GOLANG_DOWNLOAD_SHA256 afe956b6d323c68fbd851f4e962f26f16dde61d7caa1de1a8408c7de0b6034aa
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/1.7/alpine/Dockerfile
+++ b/1.7/alpine/Dockerfile
@@ -2,9 +2,9 @@ FROM alpine:3.4
 
 RUN apk add --no-cache ca-certificates
 
-ENV GOLANG_VERSION 1.7beta2
+ENV GOLANG_VERSION 1.7rc1
 ENV GOLANG_SRC_URL https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz
-ENV GOLANG_SRC_SHA256 88840e78905bdff7c8e408385182b4f77e8bdd062cac5c0c6382630588d426c7
+ENV GOLANG_SRC_SHA256 f26b42ea8d3de92efda5e2f7172b22d59e19676f23bbcf64412b32b4f4a5ff58
 
 # https://golang.org/issue/14851
 COPY no-pic.patch /

--- a/1.7/wheezy/Dockerfile
+++ b/1.7/wheezy/Dockerfile
@@ -8,9 +8,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		make \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION 1.7beta2
+ENV GOLANG_VERSION 1.7rc1
 ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 688f895b51def9e065fb2610ff91afcb2b0d9637233b74130c8ca331d35d5ca5
+ENV GOLANG_DOWNLOAD_SHA256 afe956b6d323c68fbd851f4e962f26f16dde61d7caa1de1a8408c7de0b6034aa
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \


### PR DESCRIPTION
This is a careful lexical replacement. I haven't tested, but it should be sound. Based on 13b4447729b4367396148cc18745c9901e5fe4a8.

Ping @tianon.