### PR TITLE
Install git in alpine images

### DIFF
--- a/1.5/alpine/Dockerfile
+++ b/1.5/alpine/Dockerfile
@@ -13,6 +13,7 @@ RUN set -ex \
 		musl-dev \
 		openssl \
 		go \
+		git \
 	\
 	&& export GOROOT_BOOTSTRAP="$(go env GOROOT)" \
 	\

--- a/1.6/alpine/Dockerfile
+++ b/1.6/alpine/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex \
 		musl-dev \
 		openssl \
 		go \
+		git \
 	\
 	&& export GOROOT_BOOTSTRAP="$(go env GOROOT)" \
 	\

--- a/1.7/alpine/Dockerfile
+++ b/1.7/alpine/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex \
 		musl-dev \
 		openssl \
 		go \
+		git \
 	\
 	&& export GOROOT_BOOTSTRAP="$(go env GOROOT)" \
 	\


### PR DESCRIPTION
Currently the golang alpine images do not contain `git`, which comes default in the debian based golang images. 

This makes it impossible to run `go get` with an alpine based image. The availability of `git` and go dependency fetching should be consistent across both alpine and debian based images.