### PR TITLE
GoLint utility for Debian-based images

### DIFF
--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -23,4 +23,7 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH
 
+RUN go get -u github.com/golang/lint/golint \
+    && rm -rf "$GOPATH/src"/* "$GOPATH/pkg"
+
 COPY go-wrapper /usr/local/bin/

--- a/1.6/wheezy/Dockerfile
+++ b/1.6/wheezy/Dockerfile
@@ -23,4 +23,7 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH
 
+RUN go get -u github.com/golang/lint/golint \
+    && rm -rf "$GOPATH/src"/* "$GOPATH/pkg"
+
 COPY go-wrapper /usr/local/bin/

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -23,4 +23,7 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH
 
+RUN go get -u github.com/golang/lint/golint \
+    && rm -rf "$GOPATH/src"/* "$GOPATH/pkg"
+
 COPY go-wrapper /usr/local/bin/

--- a/1.7/wheezy/Dockerfile
+++ b/1.7/wheezy/Dockerfile
@@ -23,4 +23,7 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH
 
+RUN go get -u github.com/golang/lint/golint \
+    && rm -rf "$GOPATH/src"/* "$GOPATH/pkg"
+
 COPY go-wrapper /usr/local/bin/


### PR DESCRIPTION
Install the golint utility to the Debian-based images to
be able validate the Go code before the building binaries.

The golint utility is not going to be installed into the
Alpine-based images, as their size should be as small as
possible.

closes #102