### PR TITLE
Add nanoserver variants

### DIFF
--- a/1.6/windows/nanoserver/Dockerfile
+++ b/1.6/windows/nanoserver/Dockerfile
@@ -1,0 +1,42 @@
+FROM microsoft/nanoserver
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
+
+# no Git installed (intentionally)
+#  -- Nano Server is "Windows Slim"
+
+# ideally, this would be C:\go to match Linux a bit closer, but C:\go is the recommended install path for Go itself on Windows
+ENV GOPATH C:\\gopath
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+# Nano Server does not have "[Environment]::SetEnvironmentVariable()"
+	setx /M PATH $newPath;
+# doing this first to share cache across versions more aggressively
+
+ENV GOLANG_VERSION 1.6.3
+ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.windows-amd64.zip
+ENV GOLANG_DOWNLOAD_SHA256 6a18e5ed8b39785338986aecc6a3f36f5c4be286ff52db0ae3bcd2275ab70df0
+
+RUN Write-Host ('Downloading {0} ...' -f $env:GOLANG_DOWNLOAD_URL); \
+	Invoke-WebRequest -Uri $env:GOLANG_DOWNLOAD_URL -OutFile 'go.zip'; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GOLANG_DOWNLOAD_SHA256); \
+	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $env:GOLANG_DOWNLOAD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive go.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Complete.';
+
+WORKDIR $GOPATH

--- a/1.6/windows/windowsservercore/Dockerfile
+++ b/1.6/windows/windowsservercore/Dockerfile
@@ -9,7 +9,7 @@ ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${
 ENV GIT_DOWNLOAD_SHA256 006d971bcbe73cc8d841a100a4eb20d22e135142bf5b0f2120722fd420e166e5
 # steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
 RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
-	(New-Object System.Net.WebClient).DownloadFile($env:GIT_DOWNLOAD_URL, 'git.exe'); \
+	Invoke-WebRequest -Uri $env:GIT_DOWNLOAD_URL -OutFile 'git.exe'; \
 	\
 	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_DOWNLOAD_SHA256); \
 	if ((Get-FileHash git.exe -Algorithm sha256).Hash -ne $env:GIT_DOWNLOAD_SHA256) { \
@@ -55,7 +55,9 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 ENV GOPATH C:\\gopath
 
 # PATH isn't actually set in the Docker image, so we have to set it from within the container
-RUN [Environment]::SetEnvironmentVariable('PATH', $env:GOPATH + '\bin;C:\go\bin;' + $env:PATH, [EnvironmentVariableTarget]::Machine);
+RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
 ENV GOLANG_VERSION 1.6.3
@@ -63,7 +65,7 @@ ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.windows-amd64.zi
 ENV GOLANG_DOWNLOAD_SHA256 6a18e5ed8b39785338986aecc6a3f36f5c4be286ff52db0ae3bcd2275ab70df0
 
 RUN Write-Host ('Downloading {0} ...' -f $env:GOLANG_DOWNLOAD_URL); \
-	(New-Object System.Net.WebClient).DownloadFile($env:GOLANG_DOWNLOAD_URL, 'go.zip'); \
+	Invoke-WebRequest -Uri $env:GOLANG_DOWNLOAD_URL -OutFile 'go.zip'; \
 	\
 	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GOLANG_DOWNLOAD_SHA256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $env:GOLANG_DOWNLOAD_SHA256) { \

--- a/1.7/windows/nanoserver/Dockerfile
+++ b/1.7/windows/nanoserver/Dockerfile
@@ -1,0 +1,42 @@
+FROM microsoft/nanoserver
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
+
+# no Git installed (intentionally)
+#  -- Nano Server is "Windows Slim"
+
+# ideally, this would be C:\go to match Linux a bit closer, but C:\go is the recommended install path for Go itself on Windows
+ENV GOPATH C:\\gopath
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+# Nano Server does not have "[Environment]::SetEnvironmentVariable()"
+	setx /M PATH $newPath;
+# doing this first to share cache across versions more aggressively
+
+ENV GOLANG_VERSION 1.7.1
+ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.windows-amd64.zip
+ENV GOLANG_DOWNLOAD_SHA256 af2b836bb894672cf4c28df32a2ee3ff560e2b463e1ab44bb99833064ba09e5f
+
+RUN Write-Host ('Downloading {0} ...' -f $env:GOLANG_DOWNLOAD_URL); \
+	Invoke-WebRequest -Uri $env:GOLANG_DOWNLOAD_URL -OutFile 'go.zip'; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GOLANG_DOWNLOAD_SHA256); \
+	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $env:GOLANG_DOWNLOAD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive go.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Complete.';
+
+WORKDIR $GOPATH

--- a/1.7/windows/windowsservercore/Dockerfile
+++ b/1.7/windows/windowsservercore/Dockerfile
@@ -9,7 +9,7 @@ ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${
 ENV GIT_DOWNLOAD_SHA256 006d971bcbe73cc8d841a100a4eb20d22e135142bf5b0f2120722fd420e166e5
 # steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
 RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
-	(New-Object System.Net.WebClient).DownloadFile($env:GIT_DOWNLOAD_URL, 'git.exe'); \
+	Invoke-WebRequest -Uri $env:GIT_DOWNLOAD_URL -OutFile 'git.exe'; \
 	\
 	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_DOWNLOAD_SHA256); \
 	if ((Get-FileHash git.exe -Algorithm sha256).Hash -ne $env:GIT_DOWNLOAD_SHA256) { \
@@ -55,7 +55,9 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 ENV GOPATH C:\\gopath
 
 # PATH isn't actually set in the Docker image, so we have to set it from within the container
-RUN [Environment]::SetEnvironmentVariable('PATH', $env:GOPATH + '\bin;C:\go\bin;' + $env:PATH, [EnvironmentVariableTarget]::Machine);
+RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
 ENV GOLANG_VERSION 1.7.1
@@ -63,7 +65,7 @@ ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.windows-amd64.zi
 ENV GOLANG_DOWNLOAD_SHA256 af2b836bb894672cf4c28df32a2ee3ff560e2b463e1ab44bb99833064ba09e5f
 
 RUN Write-Host ('Downloading {0} ...' -f $env:GOLANG_DOWNLOAD_URL); \
-	(New-Object System.Net.WebClient).DownloadFile($env:GOLANG_DOWNLOAD_URL, 'go.zip'); \
+	Invoke-WebRequest -Uri $env:GOLANG_DOWNLOAD_URL -OutFile 'go.zip'; \
 	\
 	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GOLANG_DOWNLOAD_SHA256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $env:GOLANG_DOWNLOAD_SHA256) { \


### PR DESCRIPTION
Build log:
```console
$ docker build 1.7/windows/nanoserver
Sending build context to Docker daemon 3.584 kB
Step 1/9 : FROM microsoft/nanoserver
 ---> e14bc0ecea12
Step 2/9 : SHELL powershell -Command $ErrorActionPreference = 'Stop';
 ---> Using cache
 ---> e44346f1b4f4
Step 3/9 : ENV GOPATH C:\\gopath
 ---> Using cache
 ---> 1971dfb0370e
Step 4/9 : RUN Write-Host 'Updating PATH ...';  $regPath = 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment';            $oldPath = (    Get-ItemProperty                -Path $regPath          -Name PATH      ).path;         Write-Host ('  Before: {0}' -f $oldPath);          $newPath = $env:GOPATH + '\bin;C:\go\bin;' + $oldPath;  Write-Host ('  After:  {0}' -f $newPath);               Set-ItemProperty           -Path $regPath          -Name PATH              -Value $newPath;        Write-Host 'Complete.';
 ---> Running in 7f60e9ea6a5c
Updating PATH ...
 Before: C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\
 After: C:\gopath\bin;C:\go\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\
Complete.
 ---> c783121c618a
Removing intermediate container 7f60e9ea6a5c
Step 5/9 : ENV GOLANG_VERSION 1.7.1
 ---> Running in 909f38eb7885
 ---> 227398d6d8a3
Removing intermediate container 909f38eb7885
Step 6/9 : ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.windows-amd64.zip
 ---> Running in a1116d1046f9
 ---> 23b31b755435
Removing intermediate container a1116d1046f9
Step 7/9 : ENV GOLANG_DOWNLOAD_SHA256 af2b836bb894672cf4c28df32a2ee3ff560e2b463e1ab44bb99833064ba09e5f
 ---> Running in 30717a793678
 ---> 8674f8a41341
Removing intermediate container 30717a793678
Step 8/9 : RUN Write-Host ('Downloading {0} ...' -f $env:GOLANG_DOWNLOAD_URL);  Invoke-WebRequest -Uri $env:GOLANG_DOWNLOAD_URL -OutFile 'go.zip'; Write-Host ('Verifying sha256 ({0}) ...' -f $env:GOLANG_DOWNLOAD_SHA256);       if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $env:GOLANG_DOWNLOAD_SHA256) {                Write-Host 'FAILED!';           exit 1;         };              Write-Host 'Expanding ...';     Expand-Archive go.zip -DestinationPath C:\;                Write-Host 'Verifying install ("go version") ...';      go version;             Write-Host 'Removing ...'; Remove-Item go.zip -Force;              Write-Host 'Complete.';
 ---> Running in 759cb3bc667e
Downloading https://golang.org/dl/go1.7.1.windows-amd64.zip ...
Verifying sha256 (af2b836bb894672cf4c28df32a2ee3ff560e2b463e1ab44bb99833064ba09e5f) ...
Expanding ...
Verifying install (go version) ...
go version go1.7.1 windows/amd64
Removing ...
Complete.
 ---> 8c1060d8ea8a
Removing intermediate container 759cb3bc667e
Step 9/9 : WORKDIR $GOPATH
 ---> Running in 30e569aa4a18
 ---> 5bcb73261c5b
Removing intermediate container 30e569aa4a18
Successfully built 5bcb73261c5b
```

```console
$ docker build 1.6/windows/nanoserver
Sending build context to Docker daemon 3.584 kB
Step 1/9 : FROM microsoft/nanoserver
 ---> e14bc0ecea12
Step 2/9 : SHELL powershell -Command $ErrorActionPreference = 'Stop';
 ---> Using cache
 ---> e44346f1b4f4
Step 3/9 : ENV GOPATH C:\\gopath
 ---> Using cache
 ---> 1971dfb0370e
Step 4/9 : RUN Write-Host 'Updating PATH ...';  $regPath = 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment';            $oldPath = (    Get-ItemProperty                -Path $regPath          -Name PATH      ).path;         Write-Host ('  Before: {0}' -f $oldPath);          $newPath = $env:GOPATH + '\bin;C:\go\bin;' + $oldPath;  Write-Host ('  After:  {0}' -f $newPath);               Set-ItemProperty           -Path $regPath          -Name PATH              -Value $newPath;        Write-Host 'Complete.';
 ---> Using cache
 ---> c783121c618a
Step 5/9 : ENV GOLANG_VERSION 1.6.3
 ---> Running in 91b72fe396ad
 ---> 56cb42f6de5b
Removing intermediate container 91b72fe396ad
Step 6/9 : ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.windows-amd64.zip
 ---> Running in edf536cb32a7
 ---> 9012a2f91318
Removing intermediate container edf536cb32a7
Step 7/9 : ENV GOLANG_DOWNLOAD_SHA256 6a18e5ed8b39785338986aecc6a3f36f5c4be286ff52db0ae3bcd2275ab70df0
 ---> Running in cd4325932625
 ---> d89e6d5bb5f9
Removing intermediate container cd4325932625
Step 8/9 : RUN Write-Host ('Downloading {0} ...' -f $env:GOLANG_DOWNLOAD_URL);  Invoke-WebRequest -Uri $env:GOLANG_DOWNLOAD_URL -OutFile 'go.zip'; Write-Host ('Verifying sha256 ({0}) ...' -f $env:GOLANG_DOWNLOAD_SHA256);       if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $env:GOLANG_DOWNLOAD_SHA256) {                Write-Host 'FAILED!';           exit 1;         };              Write-Host 'Expanding ...';     Expand-Archive go.zip -DestinationPath C:\;                Write-Host 'Verifying install ("go version") ...';      go version;             Write-Host 'Removing ...'; Remove-Item go.zip -Force;              Write-Host 'Complete.';
 ---> Running in 156a886a5ba3
Downloading https://golang.org/dl/go1.6.3.windows-amd64.zip ...
Verifying sha256 (6a18e5ed8b39785338986aecc6a3f36f5c4be286ff52db0ae3bcd2275ab70df0) ...
Expanding ...
Verifying install (go version) ...
go version go1.6.3 windows/amd64
Removing ...
Complete.
 ---> 342fc585ebd1
Removing intermediate container 156a886a5ba3
Step 9/9 : WORKDIR $GOPATH
 ---> Running in a9ba16943437
 ---> 79a8be691d8d
Removing intermediate container a9ba16943437
Successfully built 79a8be691d8d
```

Go 1.7 is ~1.12GB total, Go 1.6 is ~1.19GB total.