### PR TITLE
Revert Alpine 3.5 upgrade in 1.6 and 1.7 (leaving 1.8 on Alpine 3.5)

### DIFF
--- a/1.6/alpine/Dockerfile
+++ b/1.6/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.4
 
 RUN apk add --no-cache ca-certificates
 

--- a/1.7/alpine/Dockerfile
+++ b/1.7/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.4
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
See https://github.com/docker-library/golang/pull/131#issuecomment-270677556 for further discussion.