### PR TITLE
Added git, so 'go get' works with git deps

### DIFF
--- a/1.8/alpine/Dockerfile
+++ b/1.8/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.5
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates it
 
 ENV GOLANG_VERSION 1.8
 ENV GOLANG_SRC_URL https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz


### PR DESCRIPTION
Currently the alpine image doesn't include git, so following will happen if the dependencies a in a git repo:

go: missing Git command. See https://golang.org/s/gogetcmd