### PR TITLE
Add alpine3.6 variants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ env:
   - VERSION=1.8 VARIANT=
   - VERSION=1.8 VARIANT=stretch
   - VERSION=1.8 VARIANT=alpine
+  - VERSION=1.8 VARIANT=alpine3.6
   - VERSION=1.7 VARIANT=
   - VERSION=1.7 VARIANT=wheezy
   - VERSION=1.7 VARIANT=alpine
+  - VERSION=1.7 VARIANT=alpine3.6
   - VERSION=1.7 VARIANT=alpine3.5
 
 install:

--- a/1.7/alpine3.6/17847.patch
+++ b/1.7/alpine3.6/17847.patch
@@ -1,0 +1,33 @@
+diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
+index 14f4fa9..bf2de57 100644
+--- a/src/cmd/link/internal/ld/lib.go
++++ b/src/cmd/link/internal/ld/lib.go
+@@ -1251,6 +1251,28 @@ func hostlink() {
+ 		}
+ 	}
+ 
++	// When building a program with the default -buildmode=exe the
++	// gc compiler generates code requires DT_TEXTREL in a
++	// position independent executable (PIE). On systems where the
++	// toolchain creates PIEs by default, and where DT_TEXTREL
++	// does not work, the resulting programs will not run. See
++	// issue #17847. To avoid this problem pass -no-pie to the
++	// toolchain if it is supported.
++	if Buildmode == BuildmodeExe {
++		src := filepath.Join(tmpdir, "trivial.c")
++		if err := ioutil.WriteFile(src, []byte{}, 0666); err != nil {
++			Ctxt.Diag("WriteFile trivial.c failed: %v", err)
++		}
++		cmd := exec.Command(argv[0], "-c", "-no-pie", "trivial.c")
++		cmd.Dir = tmpdir
++		cmd.Env = append([]string{"LC_ALL=C"}, os.Environ()...)
++		out, err := cmd.CombinedOutput()
++		supported := err == nil && !bytes.Contains(out, []byte("unrecognized"))
++		if supported {
++			argv = append(argv, "-no-pie")
++		}
++	}
++
+ 	for _, p := range strings.Fields(extldflags) {
+ 		argv = append(argv, p)
+ 

--- a/1.7/alpine3.6/Dockerfile
+++ b/1.7/alpine3.6/Dockerfile
@@ -1,0 +1,56 @@
+FROM alpine:3.6
+
+RUN apk add --no-cache ca-certificates
+
+ENV GOLANG_VERSION 1.7.6
+
+# https://golang.org/issue/14851 (Go 1.8 & 1.7)
+# https://golang.org/issue/17847 (Go 1.7)
+COPY *.patch /go-alpine-patches/
+
+RUN set -eux; \
+	apk add --no-cache --virtual .build-deps \
+		bash \
+		gcc \
+		musl-dev \
+		openssl \
+		go \
+	; \
+	export \
+# set GOROOT_BOOTSTRAP such that we can actually build Go
+		GOROOT_BOOTSTRAP="$(go env GOROOT)" \
+# ... and set "cross-building" related vars to the installed system's values so that we create a build targeting the proper arch
+# (for example, if our build host is GOARCH=amd64, but our build env/image is GOARCH=386, our build needs GOARCH=386)
+		GOOS="$(go env GOOS)" \
+		GOARCH="$(go env GOARCH)" \
+		GO386="$(go env GO386)" \
+		GOARM="$(go env GOARM)" \
+		GOHOSTOS="$(go env GOHOSTOS)" \
+		GOHOSTARCH="$(go env GOHOSTARCH)" \
+	; \
+	\
+	wget -O go.tgz "https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz"; \
+	echo '1a67a4e688673fdff7ba41e73482b0e59ac5bd0f7acf703bc6d50cc775c5baba *go.tgz' | sha256sum -c -; \
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+	cd /usr/local/go/src; \
+	for p in /go-alpine-patches/*.patch; do \
+		[ -f "$p" ] || continue; \
+		patch -p2 -i "$p"; \
+	done; \
+	./make.bash; \
+	\
+	rm -rf /go-alpine-patches; \
+	apk del .build-deps; \
+	\
+	export PATH="/usr/local/go/bin:$PATH"; \
+	go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH
+
+COPY go-wrapper /usr/local/bin/

--- a/1.7/alpine3.6/go-wrapper
+++ b/1.7/alpine3.6/go-wrapper
@@ -1,0 +1,97 @@
+#!/bin/sh
+set -e
+
+usage() {
+	base="$(basename "$0")"
+	cat <<EOUSAGE
+
+usage: $base command [args]
+
+This script assumes that is is run from the root of your Go package (for
+example, "/go/src/app" if your GOPATH is set to "/go").
+
+In Go 1.4, a feature was introduced to supply the canonical "import path" for a
+given package in a comment attached to a package statement
+(https://golang.org/s/go14customimport).
+
+This script allows us to take a generic directory of Go source files such as
+"/go/src/app" and determine that the canonical "import path" of where that code
+expects to live and reference itself is "github.com/jsmith/my-cool-app".  It
+will then ensure that "/go/src/github.com/jsmith/my-cool-app" is a symlink to
+"/go/src/app", which allows us to build and run it under the proper package
+name.
+
+For compatibility with versions of Go older than 1.4, the "import path" may also
+be placed in a file named ".godir".
+
+Available Commands:
+
+  $base download
+  $base download -u
+    (equivalent to "go get -d [args] [godir]")
+
+  $base install
+  $base install -race
+    (equivalent to "go install [args] [godir]")
+
+  $base run
+  $base run -app -specific -arguments
+    (assumes "GOPATH/bin" is in "PATH")
+
+EOUSAGE
+}
+
+# make sure there is a subcommand specified
+if [ "$#" -eq 0 ]; then
+	usage >&2
+	exit 1
+fi
+# "shift" so that "$@" becomes the remaining arguments and can be passed along to other "go" subcommands easily
+cmd="$1"
+shift
+
+goDir="$(go list -e -f '{{.ImportComment}}' 2>/dev/null || true)"
+
+if [ -z "$goDir" -a -s .godir ]; then
+	goDir="$(cat .godir)"
+fi
+
+dir="$(pwd -P)"
+if [ "$goDir" ]; then
+	goPath="${GOPATH%%:*}" # this just grabs the first path listed in GOPATH, if there are multiple (which is the detection logic "go get" itself uses, too)
+	goDirPath="$goPath/src/$goDir"
+	mkdir -p "$(dirname "$goDirPath")"
+	if [ ! -e "$goDirPath" ]; then
+		ln -sfv "$dir" "$goDirPath"
+	elif [ ! -L "$goDirPath" ]; then
+		echo >&2 "error: $goDirPath already exists but is unexpectedly not a symlink!"
+		exit 1
+	fi
+	goBin="$goPath/bin/$(basename "$goDir")"
+else
+	goBin="$(basename "$dir")" # likely "app"
+fi
+
+case "$cmd" in
+	download)
+		set -- go get -v -d "$@"
+		if [ "$goDir" ]; then set -- "$@" "$goDir"; fi
+		set -x; exec "$@"
+		;;
+		
+	install)
+		set -- go install -v "$@"
+		if [ "$goDir" ]; then set -- "$@" "$goDir"; fi
+		set -x; exec "$@"
+		;;
+		
+	run)
+		set -x; exec "$goBin" "$@"
+		;;
+		
+	*)
+		echo >&2 'error: unknown command:' "$cmd"
+		usage >&2
+		exit 1
+		;;
+esac

--- a/1.7/alpine3.6/no-pic.patch
+++ b/1.7/alpine3.6/no-pic.patch
@@ -1,0 +1,16 @@
+diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
+index 14f4fa9..5599307 100644
+--- a/src/cmd/link/internal/ld/lib.go
++++ b/src/cmd/link/internal/ld/lib.go
+@@ -1272,6 +1272,11 @@ func hostlink() {
+ 		argv = append(argv, peimporteddlls()...)
+ 	}
+ 
++	// The Go linker does not currently support building PIE
++	// executables when using the external linker. See:
++	// https://github.com/golang/go/issues/6940
++	argv = append(argv, "-fno-PIC")
++
+ 	if Debug['v'] != 0 {
+ 		fmt.Fprintf(Bso, "host link:")
+ 		for _, v := range argv {

--- a/1.8/alpine3.6/Dockerfile
+++ b/1.8/alpine3.6/Dockerfile
@@ -1,0 +1,56 @@
+FROM alpine:3.6
+
+RUN apk add --no-cache ca-certificates
+
+ENV GOLANG_VERSION 1.8.3
+
+# https://golang.org/issue/14851 (Go 1.8 & 1.7)
+# https://golang.org/issue/17847 (Go 1.7)
+COPY *.patch /go-alpine-patches/
+
+RUN set -eux; \
+	apk add --no-cache --virtual .build-deps \
+		bash \
+		gcc \
+		musl-dev \
+		openssl \
+		go \
+	; \
+	export \
+# set GOROOT_BOOTSTRAP such that we can actually build Go
+		GOROOT_BOOTSTRAP="$(go env GOROOT)" \
+# ... and set "cross-building" related vars to the installed system's values so that we create a build targeting the proper arch
+# (for example, if our build host is GOARCH=amd64, but our build env/image is GOARCH=386, our build needs GOARCH=386)
+		GOOS="$(go env GOOS)" \
+		GOARCH="$(go env GOARCH)" \
+		GO386="$(go env GO386)" \
+		GOARM="$(go env GOARM)" \
+		GOHOSTOS="$(go env GOHOSTOS)" \
+		GOHOSTARCH="$(go env GOHOSTARCH)" \
+	; \
+	\
+	wget -O go.tgz "https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz"; \
+	echo '5f5dea2447e7dcfdc50fa6b94c512e58bfba5673c039259fd843f68829d99fa6 *go.tgz' | sha256sum -c -; \
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+	cd /usr/local/go/src; \
+	for p in /go-alpine-patches/*.patch; do \
+		[ -f "$p" ] || continue; \
+		patch -p2 -i "$p"; \
+	done; \
+	./make.bash; \
+	\
+	rm -rf /go-alpine-patches; \
+	apk del .build-deps; \
+	\
+	export PATH="/usr/local/go/bin:$PATH"; \
+	go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH
+
+COPY go-wrapper /usr/local/bin/

--- a/1.8/alpine3.6/go-wrapper
+++ b/1.8/alpine3.6/go-wrapper
@@ -1,0 +1,97 @@
+#!/bin/sh
+set -e
+
+usage() {
+	base="$(basename "$0")"
+	cat <<EOUSAGE
+
+usage: $base command [args]
+
+This script assumes that is is run from the root of your Go package (for
+example, "/go/src/app" if your GOPATH is set to "/go").
+
+In Go 1.4, a feature was introduced to supply the canonical "import path" for a
+given package in a comment attached to a package statement
+(https://golang.org/s/go14customimport).
+
+This script allows us to take a generic directory of Go source files such as
+"/go/src/app" and determine that the canonical "import path" of where that code
+expects to live and reference itself is "github.com/jsmith/my-cool-app".  It
+will then ensure that "/go/src/github.com/jsmith/my-cool-app" is a symlink to
+"/go/src/app", which allows us to build and run it under the proper package
+name.
+
+For compatibility with versions of Go older than 1.4, the "import path" may also
+be placed in a file named ".godir".
+
+Available Commands:
+
+  $base download
+  $base download -u
+    (equivalent to "go get -d [args] [godir]")
+
+  $base install
+  $base install -race
+    (equivalent to "go install [args] [godir]")
+
+  $base run
+  $base run -app -specific -arguments
+    (assumes "GOPATH/bin" is in "PATH")
+
+EOUSAGE
+}
+
+# make sure there is a subcommand specified
+if [ "$#" -eq 0 ]; then
+	usage >&2
+	exit 1
+fi
+# "shift" so that "$@" becomes the remaining arguments and can be passed along to other "go" subcommands easily
+cmd="$1"
+shift
+
+goDir="$(go list -e -f '{{.ImportComment}}' 2>/dev/null || true)"
+
+if [ -z "$goDir" -a -s .godir ]; then
+	goDir="$(cat .godir)"
+fi
+
+dir="$(pwd -P)"
+if [ "$goDir" ]; then
+	goPath="${GOPATH%%:*}" # this just grabs the first path listed in GOPATH, if there are multiple (which is the detection logic "go get" itself uses, too)
+	goDirPath="$goPath/src/$goDir"
+	mkdir -p "$(dirname "$goDirPath")"
+	if [ ! -e "$goDirPath" ]; then
+		ln -sfv "$dir" "$goDirPath"
+	elif [ ! -L "$goDirPath" ]; then
+		echo >&2 "error: $goDirPath already exists but is unexpectedly not a symlink!"
+		exit 1
+	fi
+	goBin="$goPath/bin/$(basename "$goDir")"
+else
+	goBin="$(basename "$dir")" # likely "app"
+fi
+
+case "$cmd" in
+	download)
+		set -- go get -v -d "$@"
+		if [ "$goDir" ]; then set -- "$@" "$goDir"; fi
+		set -x; exec "$@"
+		;;
+		
+	install)
+		set -- go install -v "$@"
+		if [ "$goDir" ]; then set -- "$@" "$goDir"; fi
+		set -x; exec "$@"
+		;;
+		
+	run)
+		set -x; exec "$goBin" "$@"
+		;;
+		
+	*)
+		echo >&2 'error: unknown command:' "$cmd"
+		usage >&2
+		exit 1
+		;;
+esac

--- a/1.8/alpine3.6/no-pic.patch
+++ b/1.8/alpine3.6/no-pic.patch
@@ -1,0 +1,16 @@
+diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
+index 14f4fa9..5599307 100644
+--- a/src/cmd/link/internal/ld/lib.go
++++ b/src/cmd/link/internal/ld/lib.go
+@@ -1272,6 +1272,11 @@ func hostlink() {
+ 		argv = append(argv, peimporteddlls()...)
+ 	}
+ 
++	// The Go linker does not currently support building PIE
++	// executables when using the external linker. See:
++	// https://github.com/golang/go/issues/6940
++	argv = append(argv, "-fno-PIC")
++
+ 	if l.Debugvlog != 0 {
+ 		l.Logf("%5.2f host link:", obj.Cputime())
+ 		for _, v := range argv {

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -79,7 +79,7 @@ for version in "${versions[@]}"; do
 	EOE
 
 	for v in \
-		onbuild wheezy stretch alpine alpine3.5 \
+		onbuild wheezy stretch alpine alpine3.6 alpine3.5 \
 		windows/windowsservercore windows/nanoserver \
 	; do
 		dir="$version/$v"

--- a/update.sh
+++ b/update.sh
@@ -16,9 +16,10 @@ declare -A debianSuite=(
 	[1.8]='jessie'
 	[1.7]='jessie'
 )
-defaultAlpineVersion='3.5'
+defaultAlpineVersion='3.6'
 declare -A alpineVersion=(
 	[1.7]='3.4'
+	[1.8]='3.5'
 )
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
@@ -91,7 +92,7 @@ for version in "${versions[@]}"; do
 
 	windowsSha256="$(curl -fsSL "https://storage.googleapis.com/golang/go${fullVersion}.windows-amd64.zip.sha256")"
 
-	for variant in alpine3.5 alpine; do
+	for variant in alpine3.5 alpine3.6 alpine; do
 		if [ -d "$version/$variant" ]; then
 			ver="${variant#alpine}"
 			ver="${ver:-${alpineVersion[$version]:-$defaultAlpineVersion}}"


### PR DESCRIPTION
FYI @dhiltgen @dmp42 @ncopa

(This will get us `s390x/golang`+Alpine support -- they're built from the same sources as-is.)