### PR TITLE
Update 1.10beta2

### DIFF
--- a/1.10-rc/alpine3.7/Dockerfile
+++ b/1.10-rc/alpine3.7/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.7
 
 RUN apk add --no-cache ca-certificates
 
-ENV GOLANG_VERSION 1.10beta1
+ENV GOLANG_VERSION 1.10beta2
 
 # no-pic.patch: https://golang.org/issue/14851 (Go 1.8 & 1.7)
 COPY *.patch /go-alpine-patches/

--- a/1.10-rc/stretch/Dockerfile
+++ b/1.10-rc/stretch/Dockerfile
@@ -9,20 +9,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		pkg-config \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION 1.10beta1
+ENV GOLANG_VERSION 1.10beta2
 
 RUN set -eux; \
 	\
 # this "case" statement is generated via "update.sh"
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "${dpkgArch##*-}" in \
-		amd64) goRelArch='linux-amd64'; goRelSha256='ec7a10b5bf147a8e06cf64e27384ff3c6d065c74ebd8fdd31f572714f74a1055' ;; \
-		armhf) goRelArch='linux-armv6l'; goRelSha256='32daa257a930ef85ca74bca107d477b3484f0b5ef7cc48086110916368d9c584' ;; \
-		arm64) goRelArch='linux-arm64'; goRelSha256='3a80555b3c4beecfb9af88c718f8676101ada74dea84f4aa1ade29d2d78554e0' ;; \
-		i386) goRelArch='linux-386'; goRelSha256='e0f30e18384e3beae8ce16cc6d095d899e29fb786c57297650acb7727fb3090e' ;; \
-		ppc64el) goRelArch='linux-ppc64le'; goRelSha256='b4c7404771b380212277fecc3b9a4f99f9978d024a45d3644c495a469df31ed8' ;; \
-		s390x) goRelArch='linux-s390x'; goRelSha256='bc3c66ab980e782ce52165a3a1572484353904c1b884dbbb87a662776280489d' ;; \
-		*) goRelArch='src'; goRelSha256='841df62b20fd915d83a2e43b7d043c2a3781c299de78abc45480eec575186b6b'; \
+		amd64) goRelArch='linux-amd64'; goRelSha256='ab3abb7d731dd5ac7a06d5d5e64ef19946f57d4ce34555d262a87b8899901a93' ;; \
+		armhf) goRelArch='linux-armv6l'; goRelSha256='777a59c2b1516598e161c0c5b25809c83fdec3737a0b7f4942c855259d57b3fe' ;; \
+		arm64) goRelArch='linux-arm64'; goRelSha256='2f51e94a227473d41bf3d9dbbdc5855308e64d82fb740a15019bd4fe733c9518' ;; \
+		i386) goRelArch='linux-386'; goRelSha256='4e5bc465a828c88e0e3c6049c58ee735d8ca27a994bc1d709424425cd20cab79' ;; \
+		ppc64el) goRelArch='linux-ppc64le'; goRelSha256='ace75d03dc73351320d055535f1f314b7dbd27ab21c7878db27a385b1e00d5b0' ;; \
+		s390x) goRelArch='linux-s390x'; goRelSha256='4d8625f071edd2cb2b16251f23530a43f9ff64db1b6ce080daff0dcc984005da' ;; \
+		*) goRelArch='src'; goRelSha256='a77c130eabfdea21fca629276f509b18da925912509903102b49113bc7dede9d'; \
 			echo >&2; echo >&2 "warning: current architecture ($dpkgArch) does not have a corresponding Go binary release; will be building from source"; echo >&2 ;; \
 	esac; \
 	\

--- a/1.10-rc/windows/nanoserver-sac2016/Dockerfile
+++ b/1.10-rc/windows/nanoserver-sac2016/Dockerfile
@@ -16,13 +16,13 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 	setx /M PATH $newPath;
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.10beta1
+ENV GOLANG_VERSION 1.10beta2
 
 RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = 'ff2789b7baf33f87111d30bac81ac1ae19dcc16bdd75553f9b5aceda14733a40'; \
+	$sha256 = 'a507ec2983047e30f7595dfd6536534d98426d0423d9141749b21d772740d4c9'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/1.10-rc/windows/windowsservercore-1709/Dockerfile
+++ b/1.10-rc/windows/windowsservercore-1709/Dockerfile
@@ -45,13 +45,13 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.10beta1
+ENV GOLANG_VERSION 1.10beta2
 
 RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = 'ff2789b7baf33f87111d30bac81ac1ae19dcc16bdd75553f9b5aceda14733a40'; \
+	$sha256 = 'a507ec2983047e30f7595dfd6536534d98426d0423d9141749b21d772740d4c9'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/1.10-rc/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/1.10-rc/windows/windowsservercore-ltsc2016/Dockerfile
@@ -45,13 +45,13 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.10beta1
+ENV GOLANG_VERSION 1.10beta2
 
 RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = 'ff2789b7baf33f87111d30bac81ac1ae19dcc16bdd75553f9b5aceda14733a40'; \
+	$sha256 = 'a507ec2983047e30f7595dfd6536534d98426d0423d9141749b21d772740d4c9'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \


### PR DESCRIPTION
```
diff -u <(bashbrew cat golang) <(bashbrew cat <(./generate-stackbrew-library.sh))
--- /dev/fd/63  2018-01-11 21:49:52.446656684 +0000
+++ /dev/fd/62  2018-01-11 21:49:52.446656684 +0000
@@ -0,0 +1,117 @@
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon), Joseph Ferguson <yosifkit@gmail.com> (@yosifkit), Johan Euphrosine <proppy@google.com> (@proppy)
+GitRepo: https://github.com/docker-library/golang.git
+
+Tags: 1.10beta2-stretch, 1.10-rc-stretch, rc-stretch
+SharedTags: 1.10beta2, 1.10-rc, rc
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 054c67af23c9c41c18703471473bf08b63a299e3
+Directory: 1.10-rc/stretch
+
+Tags: 1.10beta2-alpine3.7, 1.10-rc-alpine3.7, rc-alpine3.7, 1.10beta2-alpine, 1.10-rc-alpine, rc-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 054c67af23c9c41c18703471473bf08b63a299e3
+Directory: 1.10-rc/alpine3.7
+
+Tags: 1.10beta2-windowsservercore-ltsc2016, 1.10-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: 1.10beta2-windowsservercore, 1.10-rc-windowsservercore, rc-windowsservercore, 1.10beta2, 1.10-rc, rc
+Architectures: windows-amd64
+GitCommit: 054c67af23c9c41c18703471473bf08b63a299e3
+Directory: 1.10-rc/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 1.10beta2-windowsservercore-1709, 1.10-rc-windowsservercore-1709, rc-windowsservercore-1709
+SharedTags: 1.10beta2-windowsservercore, 1.10-rc-windowsservercore, rc-windowsservercore, 1.10beta2, 1.10-rc, rc
+Architectures: windows-amd64
+GitCommit: 054c67af23c9c41c18703471473bf08b63a299e3
+Directory: 1.10-rc/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
+
+Tags: 1.10beta2-nanoserver-sac2016, 1.10-rc-nanoserver-sac2016, rc-nanoserver-sac2016
+SharedTags: 1.10beta2-nanoserver, 1.10-rc-nanoserver, rc-nanoserver
+Architectures: windows-amd64
+GitCommit: 054c67af23c9c41c18703471473bf08b63a299e3
+Directory: 1.10-rc/windows/nanoserver-sac2016
+Constraints: nanoserver-sac2016
+
+Tags: 1.9.2-stretch, 1.9-stretch, 1-stretch, stretch
+SharedTags: 1.9.2, 1.9, 1, latest
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: cffcff7fce7f6b6b5c82fc8f7b3331a10590a661
+Directory: 1.9/stretch
+
+Tags: 1.9.2-alpine3.7, 1.9-alpine3.7, 1-alpine3.7, alpine3.7
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 1e2ddb8ec8c9f59a56ddfb343e1bd8e65440b6db
+Directory: 1.9/alpine3.7
+
+Tags: 1.9.2-alpine3.6, 1.9-alpine3.6, 1-alpine3.6, alpine3.6, 1.9.2-alpine, 1.9-alpine, 1-alpine, alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: b177ea29af72ec40ea8a77e00cfddfcaf96be6d9
+Directory: 1.9/alpine3.6
+
+Tags: 1.9.2-windowsservercore-ltsc2016, 1.9-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.9.2-windowsservercore, 1.9-windowsservercore, 1-windowsservercore, windowsservercore, 1.9.2, 1.9, 1, latest
+Architectures: windows-amd64
+GitCommit: 4ae3bfb2fefaeef55f8e5875fdd3ccadbe3bde34
+Directory: 1.9/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 1.9.2-windowsservercore-1709, 1.9-windowsservercore-1709, 1-windowsservercore-1709, windowsservercore-1709
+SharedTags: 1.9.2-windowsservercore, 1.9-windowsservercore, 1-windowsservercore, windowsservercore, 1.9.2, 1.9, 1, latest
+Architectures: windows-amd64
+GitCommit: 4ae3bfb2fefaeef55f8e5875fdd3ccadbe3bde34
+Directory: 1.9/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
+
+Tags: 1.9.2-nanoserver-sac2016, 1.9-nanoserver-sac2016, 1-nanoserver-sac2016, nanoserver-sac2016
+SharedTags: 1.9.2-nanoserver, 1.9-nanoserver, 1-nanoserver, nanoserver
+Architectures: windows-amd64
+GitCommit: 4ae3bfb2fefaeef55f8e5875fdd3ccadbe3bde34
+Directory: 1.9/windows/nanoserver-sac2016
+Constraints: nanoserver-sac2016
+
+Tags: 1.8.5-stretch, 1.8-stretch
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 87aaffce8f74bc5bee1306539030ee413c32aee4
+Directory: 1.8/stretch
+
+Tags: 1.8.5-jessie, 1.8-jessie
+SharedTags: 1.8.5, 1.8
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 87aaffce8f74bc5bee1306539030ee413c32aee4
+Directory: 1.8/jessie
+
+Tags: 1.8.5-alpine3.6, 1.8-alpine3.6
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: b177ea29af72ec40ea8a77e00cfddfcaf96be6d9
+Directory: 1.8/alpine3.6
+
+Tags: 1.8.5-alpine3.5, 1.8-alpine3.5, 1.8.5-alpine, 1.8-alpine
+GitCommit: b177ea29af72ec40ea8a77e00cfddfcaf96be6d9
+Directory: 1.8/alpine3.5
+
+Tags: 1.8.5-onbuild, 1.8-onbuild
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 132cd70768e3bc269902e4c7b579203f66dc9f64
+Directory: 1.8/onbuild
+
+Tags: 1.8.5-windowsservercore-ltsc2016, 1.8-windowsservercore-ltsc2016
+SharedTags: 1.8.5-windowsservercore, 1.8-windowsservercore, 1.8.5, 1.8
+Architectures: windows-amd64
+GitCommit: 4ae3bfb2fefaeef55f8e5875fdd3ccadbe3bde34
+Directory: 1.8/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 1.8.5-windowsservercore-1709, 1.8-windowsservercore-1709
+SharedTags: 1.8.5-windowsservercore, 1.8-windowsservercore, 1.8.5, 1.8
+Architectures: windows-amd64
+GitCommit: 4ae3bfb2fefaeef55f8e5875fdd3ccadbe3bde34
+Directory: 1.8/windows/windowsservercore-1709
+Constraints: windowsservercore-1709
+
+Tags: 1.8.5-nanoserver-sac2016, 1.8-nanoserver-sac2016
+SharedTags: 1.8.5-nanoserver, 1.8-nanoserver
+Architectures: windows-amd64
+GitCommit: 4ae3bfb2fefaeef55f8e5875fdd3ccadbe3bde34
+Directory: 1.8/windows/nanoserver-sac2016
+Constraints: nanoserver-sac2016
```