### PR TITLE
Install git command for alpine versions.

### DIFF
--- a/1.10-rc/alpine3.7/Dockerfile
+++ b/1.10-rc/alpine3.7/Dockerfile
@@ -13,6 +13,7 @@ RUN set -eux; \
 		gcc \
 		musl-dev \
 		openssl \
+		git \
 		go \
 	; \
 	export \

--- a/1.8/alpine3.5/Dockerfile
+++ b/1.8/alpine3.5/Dockerfile
@@ -13,6 +13,7 @@ RUN set -eux; \
 		gcc \
 		musl-dev \
 		openssl \
+		git \
 		go \
 	; \
 	export \

--- a/1.8/alpine3.6/Dockerfile
+++ b/1.8/alpine3.6/Dockerfile
@@ -13,6 +13,7 @@ RUN set -eux; \
 		gcc \
 		musl-dev \
 		openssl \
+		git \
 		go \
 	; \
 	export \

--- a/1.9/alpine3.6/Dockerfile
+++ b/1.9/alpine3.6/Dockerfile
@@ -13,6 +13,7 @@ RUN set -eux; \
 		gcc \
 		musl-dev \
 		openssl \
+		git \
 		go \
 	; \
 	export \

--- a/1.9/alpine3.7/Dockerfile
+++ b/1.9/alpine3.7/Dockerfile
@@ -13,6 +13,7 @@ RUN set -eux; \
 		gcc \
 		musl-dev \
 		openssl \
+		git \
 		go \
 	; \
 	export \


### PR DESCRIPTION
`go-wrapper` depends on `git` command.

This exception I got when used `golang:1.9-alpine`

```
Status: Downloaded newer image for golang:1.9-alpine
 ---> bbab7aea1231
Step 2/8 : WORKDIR /go/src/app
Removing intermediate container 53b495380373
 ---> f447f8a09abe
Step 3/8 : COPY . .
 ---> 1d5935656e53
Step 4/8 : RUN go-wrapper download  && go-wrapper install
 ---> Running in e953b094261b
+ exec go get -v -d
github.com/PagerDuty/go-pagerduty (download)
go: missing Git command. See https://golang.org/s/gogetcmd
package github.com/PagerDuty/go-pagerduty: exec: "git": executable file not found in $PATH
github.com/nlopes/slack (download)
go: missing Git command. See https://golang.org/s/gogetcmd
package github.com/nlopes/slack: exec: "git": executable file not found in $PATH
The command '/bin/sh -c go-wrapper download  && go-wrapper install' returned a non-zero code: 1
```