### PR TITLE
Set windows tls version for download from github

### DIFF
--- a/1.10/windows/windowsservercore-1709/Dockerfile
+++ b/1.10/windows/windowsservercore-1709/Dockerfile
@@ -13,6 +13,7 @@ ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${
 ENV GIT_DOWNLOAD_SHA256 668d16a799dd721ed126cc91bed49eb2c072ba1b25b50048280a4e2c5ed56e59
 # steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
 RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $env:GIT_DOWNLOAD_URL -OutFile 'git.zip'; \
 	\
 	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_DOWNLOAD_SHA256); \

--- a/1.10/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/1.10/windows/windowsservercore-ltsc2016/Dockerfile
@@ -13,6 +13,7 @@ ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${
 ENV GIT_DOWNLOAD_SHA256 668d16a799dd721ed126cc91bed49eb2c072ba1b25b50048280a4e2c5ed56e59
 # steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
 RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $env:GIT_DOWNLOAD_URL -OutFile 'git.zip'; \
 	\
 	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_DOWNLOAD_SHA256); \

--- a/1.9/windows/windowsservercore-1709/Dockerfile
+++ b/1.9/windows/windowsservercore-1709/Dockerfile
@@ -13,6 +13,7 @@ ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${
 ENV GIT_DOWNLOAD_SHA256 668d16a799dd721ed126cc91bed49eb2c072ba1b25b50048280a4e2c5ed56e59
 # steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
 RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $env:GIT_DOWNLOAD_URL -OutFile 'git.zip'; \
 	\
 	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_DOWNLOAD_SHA256); \

--- a/1.9/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/1.9/windows/windowsservercore-ltsc2016/Dockerfile
@@ -13,6 +13,7 @@ ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${
 ENV GIT_DOWNLOAD_SHA256 668d16a799dd721ed126cc91bed49eb2c072ba1b25b50048280a4e2c5ed56e59
 # steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
 RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $env:GIT_DOWNLOAD_URL -OutFile 'git.zip'; \
 	\
 	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_DOWNLOAD_SHA256); \

--- a/Dockerfile-windows-windowsservercore.template
+++ b/Dockerfile-windows-windowsservercore.template
@@ -13,6 +13,7 @@ ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${
 ENV GIT_DOWNLOAD_SHA256 668d16a799dd721ed126cc91bed49eb2c072ba1b25b50048280a4e2c5ed56e59
 # steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
 RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $env:GIT_DOWNLOAD_URL -OutFile 'git.zip'; \
 	\
 	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_DOWNLOAD_SHA256); \


### PR DESCRIPTION
Currently windows server builds fail because github only support Tls 1.2 but windows server defaults to tls 1.0 while downloading git-for-windows.