### PR TITLE
Add alpine3.8 flavours

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,14 @@ services: docker
 
 env:
   - VERSION=1.9 VARIANT=stretch
+  - VERSION=1.9 VARIANT=alpine3.8
   - VERSION=1.9 VARIANT=alpine3.7
   - VERSION=1.9 VARIANT=alpine3.6
   - VERSION=1.11-rc VARIANT=stretch
+  - VERSION=1.11-rc VARIANT=alpine3.8
   - VERSION=1.11-rc VARIANT=alpine3.7
   - VERSION=1.10 VARIANT=stretch
+  - VERSION=1.10 VARIANT=alpine3.8
   - VERSION=1.10 VARIANT=alpine3.7
 
 install:

--- a/1.10/alpine3.8/Dockerfile
+++ b/1.10/alpine3.8/Dockerfile
@@ -1,0 +1,64 @@
+FROM alpine:3.8
+
+RUN apk add --no-cache \
+		ca-certificates
+
+# set up nsswitch.conf for Go's "netgo" implementation
+# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+# - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
+ENV GOLANG_VERSION 1.10.3
+
+# make-sure-R0-is-zero-before-main-on-ppc64le.patch: https://github.com/golang/go/commit/9aea0e89b6df032c29d0add8d69ba2c95f1106d9 (Go 1.9)
+#COPY *.patch /go-alpine-patches/
+
+RUN set -eux; \
+	apk add --no-cache --virtual .build-deps \
+		bash \
+		gcc \
+		musl-dev \
+		openssl \
+		go \
+	; \
+	export \
+# set GOROOT_BOOTSTRAP such that we can actually build Go
+		GOROOT_BOOTSTRAP="$(go env GOROOT)" \
+# ... and set "cross-building" related vars to the installed system's values so that we create a build targeting the proper arch
+# (for example, if our build host is GOARCH=amd64, but our build env/image is GOARCH=386, our build needs GOARCH=386)
+		GOOS="$(go env GOOS)" \
+		GOARCH="$(go env GOARCH)" \
+		GOHOSTOS="$(go env GOHOSTOS)" \
+		GOHOSTARCH="$(go env GOHOSTARCH)" \
+	; \
+# also explicitly set GO386 and GOARM if appropriate
+# https://github.com/docker-library/golang/issues/184
+	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+		armhf) export GOARM='6' ;; \
+		x86) export GO386='387' ;; \
+	esac; \
+	\
+	wget -O go.tgz "https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz"; \
+	echo '567b1cc66c9704d1c019c50bef946272e911ec6baf244310f87f4e678be155f2 *go.tgz' | sha256sum -c -; \
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+	cd /usr/local/go/src; \
+	for p in /go-alpine-patches/*.patch; do \
+		[ -f "$p" ] || continue; \
+		patch -p2 -i "$p"; \
+	done; \
+	./make.bash; \
+	\
+	rm -rf /go-alpine-patches; \
+	apk del .build-deps; \
+	\
+	export PATH="/usr/local/go/bin:$PATH"; \
+	go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH

--- a/1.11-rc/alpine3.8/Dockerfile
+++ b/1.11-rc/alpine3.8/Dockerfile
@@ -1,0 +1,64 @@
+FROM alpine:3.8
+
+RUN apk add --no-cache \
+		ca-certificates
+
+# set up nsswitch.conf for Go's "netgo" implementation
+# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+# - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
+ENV GOLANG_VERSION 1.11beta1
+
+# make-sure-R0-is-zero-before-main-on-ppc64le.patch: https://github.com/golang/go/commit/9aea0e89b6df032c29d0add8d69ba2c95f1106d9 (Go 1.9)
+#COPY *.patch /go-alpine-patches/
+
+RUN set -eux; \
+	apk add --no-cache --virtual .build-deps \
+		bash \
+		gcc \
+		musl-dev \
+		openssl \
+		go \
+	; \
+	export \
+# set GOROOT_BOOTSTRAP such that we can actually build Go
+		GOROOT_BOOTSTRAP="$(go env GOROOT)" \
+# ... and set "cross-building" related vars to the installed system's values so that we create a build targeting the proper arch
+# (for example, if our build host is GOARCH=amd64, but our build env/image is GOARCH=386, our build needs GOARCH=386)
+		GOOS="$(go env GOOS)" \
+		GOARCH="$(go env GOARCH)" \
+		GOHOSTOS="$(go env GOHOSTOS)" \
+		GOHOSTARCH="$(go env GOHOSTARCH)" \
+	; \
+# also explicitly set GO386 and GOARM if appropriate
+# https://github.com/docker-library/golang/issues/184
+	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+		armhf) export GOARM='6' ;; \
+		x86) export GO386='387' ;; \
+	esac; \
+	\
+	wget -O go.tgz "https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz"; \
+	echo '5955eeb8f45e02aa5357fc18e62f1fe6c1b19e0c50aba93b8b9d9ef13b862dda *go.tgz' | sha256sum -c -; \
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+	cd /usr/local/go/src; \
+	for p in /go-alpine-patches/*.patch; do \
+		[ -f "$p" ] || continue; \
+		patch -p2 -i "$p"; \
+	done; \
+	./make.bash; \
+	\
+	rm -rf /go-alpine-patches; \
+	apk del .build-deps; \
+	\
+	export PATH="/usr/local/go/bin:$PATH"; \
+	go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH

--- a/1.9/alpine3.8/Dockerfile
+++ b/1.9/alpine3.8/Dockerfile
@@ -1,0 +1,66 @@
+FROM alpine:3.8
+
+RUN apk add --no-cache \
+		ca-certificates
+
+# set up nsswitch.conf for Go's "netgo" implementation
+# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+# - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
+ENV GOLANG_VERSION 1.9.7
+
+# make-sure-R0-is-zero-before-main-on-ppc64le.patch: https://github.com/golang/go/commit/9aea0e89b6df032c29d0add8d69ba2c95f1106d9 (Go 1.9)
+COPY *.patch /go-alpine-patches/
+
+RUN set -eux; \
+	apk add --no-cache --virtual .build-deps \
+		bash \
+		gcc \
+		musl-dev \
+		openssl \
+		go \
+	; \
+	export \
+# set GOROOT_BOOTSTRAP such that we can actually build Go
+		GOROOT_BOOTSTRAP="$(go env GOROOT)" \
+# ... and set "cross-building" related vars to the installed system's values so that we create a build targeting the proper arch
+# (for example, if our build host is GOARCH=amd64, but our build env/image is GOARCH=386, our build needs GOARCH=386)
+		GOOS="$(go env GOOS)" \
+		GOARCH="$(go env GOARCH)" \
+		GOHOSTOS="$(go env GOHOSTOS)" \
+		GOHOSTARCH="$(go env GOHOSTARCH)" \
+	; \
+# also explicitly set GO386 and GOARM if appropriate
+# https://github.com/docker-library/golang/issues/184
+	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+		armhf) export GOARM='6' ;; \
+		x86) export GO386='387' ;; \
+	esac; \
+	\
+	wget -O go.tgz "https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz"; \
+	echo '582814fa45e8ecb0859a208e517b48aa0ad951e3b36c7fff203d834e0ef27722 *go.tgz' | sha256sum -c -; \
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+	cd /usr/local/go/src; \
+	for p in /go-alpine-patches/*.patch; do \
+		[ -f "$p" ] || continue; \
+		patch -p2 -i "$p"; \
+	done; \
+	./make.bash; \
+	\
+	rm -rf /go-alpine-patches; \
+	apk del .build-deps; \
+	\
+	export PATH="/usr/local/go/bin:$PATH"; \
+	go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH
+
+COPY go-wrapper /usr/local/bin/

--- a/1.9/alpine3.8/go-wrapper
+++ b/1.9/alpine3.8/go-wrapper
@@ -1,0 +1,97 @@
+#!/bin/sh
+set -e
+
+usage() {
+	base="$(basename "$0")"
+	cat <<EOUSAGE
+
+usage: $base command [args]
+
+This script assumes that it is run from the root of your Go package (for
+example, "/go/src/app" if your GOPATH is set to "/go").
+
+In Go 1.4, a feature was introduced to supply the canonical "import path" for a
+given package in a comment attached to a package statement
+(https://golang.org/s/go14customimport).
+
+This script allows us to take a generic directory of Go source files such as
+"/go/src/app" and determine that the canonical "import path" of where that code
+expects to live and reference itself is "github.com/jsmith/my-cool-app".  It
+will then ensure that "/go/src/github.com/jsmith/my-cool-app" is a symlink to
+"/go/src/app", which allows us to build and run it under the proper package
+name.
+
+For compatibility with versions of Go older than 1.4, the "import path" may also
+be placed in a file named ".godir".
+
+Available Commands:
+
+  $base download
+  $base download -u
+    (equivalent to "go get -d [args] [godir]")
+
+  $base install
+  $base install -race
+    (equivalent to "go install [args] [godir]")
+
+  $base run
+  $base run -app -specific -arguments
+    (assumes "GOPATH/bin" is in "PATH")
+
+EOUSAGE
+}
+
+# make sure there is a subcommand specified
+if [ "$#" -eq 0 ]; then
+	usage >&2
+	exit 1
+fi
+# "shift" so that "$@" becomes the remaining arguments and can be passed along to other "go" subcommands easily
+cmd="$1"
+shift
+
+goDir="$(go list -e -f '{{.ImportComment}}' 2>/dev/null || true)"
+
+if [ -z "$goDir" -a -s .godir ]; then
+	goDir="$(cat .godir)"
+fi
+
+dir="$(pwd -P)"
+if [ "$goDir" ]; then
+	goPath="${GOPATH%%:*}" # this just grabs the first path listed in GOPATH, if there are multiple (which is the detection logic "go get" itself uses, too)
+	goDirPath="$goPath/src/$goDir"
+	mkdir -p "$(dirname "$goDirPath")"
+	if [ ! -e "$goDirPath" ]; then
+		ln -sfv "$dir" "$goDirPath"
+	elif [ ! -L "$goDirPath" ]; then
+		echo >&2 "error: $goDirPath already exists but is unexpectedly not a symlink!"
+		exit 1
+	fi
+	goBin="$goPath/bin/$(basename "$goDir")"
+else
+	goBin="$(basename "$dir")" # likely "app"
+fi
+
+case "$cmd" in
+	download)
+		set -- go get -v -d "$@"
+		if [ "$goDir" ]; then set -- "$@" "$goDir"; fi
+		set -x; exec "$@"
+		;;
+		
+	install)
+		set -- go install -v "$@"
+		if [ "$goDir" ]; then set -- "$@" "$goDir"; fi
+		set -x; exec "$@"
+		;;
+		
+	run)
+		set -x; exec "$goBin" "$@"
+		;;
+		
+	*)
+		echo >&2 'error: unknown command:' "$cmd"
+		usage >&2
+		exit 1
+		;;
+esac

--- a/1.9/alpine3.8/make-sure-R0-is-zero-before-main-on-ppc64le.patch
+++ b/1.9/alpine3.8/make-sure-R0-is-zero-before-main-on-ppc64le.patch
@@ -1,0 +1,32 @@
+From 9aea0e89b6df032c29d0add8d69ba2c95f1106d9 Mon Sep 17 00:00:00 2001
+From: Carlos Eduardo Seo <cseo@linux.vnet.ibm.com>
+Date: Thu, 10 Aug 2017 14:48:36 -0300
+Subject: [PATCH] runtime: make sure R0 is zero before _main on ppc64le
+
+_main has an early check to verify if a binary is statically or dynamically
+linked that depends on R0 being zero. R0 is not guaranteed to be zero at that
+point and this was breaking Go on Alpine for ppc64le.
+
+Change-Id: I4a1059ff7fd3db6fc489e7dcfe631c1814dd965b
+Reviewed-on: https://go-review.googlesource.com/54730
+Run-TryBot: Lynn Boger <laboger@linux.vnet.ibm.com>
+Reviewed-by: Lynn Boger <laboger@linux.vnet.ibm.com>
+---
+ src/runtime/rt0_linux_ppc64le.s | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/runtime/rt0_linux_ppc64le.s b/src/runtime/rt0_linux_ppc64le.s
+index 134858bff8..73b9ae392d 100644
+--- a/src/runtime/rt0_linux_ppc64le.s
++++ b/src/runtime/rt0_linux_ppc64le.s
+@@ -2,6 +2,7 @@
+ #include "textflag.h"
+ 
+ TEXT _rt0_ppc64le_linux(SB),NOSPLIT,$0
++	XOR R0, R0	  // Make sure R0 is zero before _main
+ 	BR _main<>(SB)
+ 
+ TEXT _rt0_ppc64le_linux_lib(SB),NOSPLIT,$-8
+-- 
+2.14.1
+

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -9,7 +9,7 @@ declare -A aliases=(
 defaultDebianSuite='stretch'
 declare -A debianSuite=(
 )
-defaultAlpineVersion='3.7'
+defaultAlpineVersion='3.8'
 declare -A alpineVersion=(
 	[1.9]='3.6'
 )
@@ -72,7 +72,7 @@ for version in "${versions[@]}"; do
 	)
 
 	for v in \
-		stretch alpine3.{7,6} \
+		stretch alpine3.{8,7,6} \
 		windows/windowsservercore-{ltsc2016,1709,1803} \
 		windows/nanoserver-{sac2016,1709,1803} \
 	; do

--- a/update.sh
+++ b/update.sh
@@ -84,7 +84,7 @@ for version in "${versions[@]}"; do
 	windowsSha256="$(curl -fsSL "https://storage.googleapis.com/golang/go${fullVersion}.windows-amd64.zip.sha256")"
 
 	for variant in \
-		alpine3.{6,7} \
+		alpine3.{6,7,8} \
 		stretch \
 	; do
 		if [ -d "$version/$variant" ]; then


### PR DESCRIPTION
```sh
diff -u <(bashbrew cat <(cat before)) <(bashbrew cat <(./generate-stackbrew-library.sh))
```
```diff
--- /dev/fd/63  2018-07-11 19:33:27.276731717 +0000
+++ /dev/fd/62  2018-07-11 19:33:27.276731717 +0000
@@ -7,7 +7,12 @@
 GitCommit: 8fdde0724a5cbc43c05cd6817ab1161450a46dcc
 Directory: 1.11-rc/stretch

-Tags: 1.11beta1-alpine3.7, 1.11-rc-alpine3.7, rc-alpine3.7, 1.11beta1-alpine, 1.11-rc-alpine, rc-alpine
+Tags: 1.11beta1-alpine3.8, 1.11-rc-alpine3.8, rc-alpine3.8, 1.11beta1-alpine, 1.11-rc-alpine, rc-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 9a0801b8d6eca9d525aa1516e10a9f3993f90d96
+Directory: 1.11-rc/alpine3.8
+
+Tags: 1.11beta1-alpine3.7, 1.11-rc-alpine3.7, rc-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 8fdde0724a5cbc43c05cd6817ab1161450a46dcc
 Directory: 1.11-rc/alpine3.7
@@ -46,7 +51,12 @@
 GitCommit: fa0223eaa427188e0c70025f557d515129a9973f
 Directory: 1.10/stretch

-Tags: 1.10.3-alpine3.7, 1.10-alpine3.7, 1-alpine3.7, alpine3.7, 1.10.3-alpine, 1.10-alpine, 1-alpine, alpine
+Tags: 1.10.3-alpine3.8, 1.10-alpine3.8, 1-alpine3.8, alpine3.8, 1.10.3-alpine, 1.10-alpine, 1-alpine, alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 9a0801b8d6eca9d525aa1516e10a9f3993f90d96
+Directory: 1.10/alpine3.8
+
+Tags: 1.10.3-alpine3.7, 1.10-alpine3.7, 1-alpine3.7, alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: fa0223eaa427188e0c70025f557d515129a9973f
 Directory: 1.10/alpine3.7
@@ -85,6 +95,11 @@
 GitCommit: 4e30a6bb9f410004a8ecd2336e589f441b7398ec
 Directory: 1.9/stretch

+Tags: 1.9.7-alpine3.8, 1.9-alpine3.8
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 9a0801b8d6eca9d525aa1516e10a9f3993f90d96
+Directory: 1.9/alpine3.8
+
 Tags: 1.9.7-alpine3.7, 1.9-alpine3.7
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: 4e30a6bb9f410004a8ecd2336e589f441b7398ec
```

```sh
$ git diff --no-index 1.9/alpine3.7 1.9/alpine3.8
```
```diff
diff --git a/1.9/alpine3.7/Dockerfile b/1.9/alpine3.8/Dockerfile
index 0959db2..e016659 100644
--- a/1.9/alpine3.7/Dockerfile
+++ b/1.9/alpine3.8/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.8

 RUN apk add --no-cache \
                ca-certificates
```
```sh
$ git diff --no-index 1.10/alpine3.7 1.10/alpine3.8
```
```diff
diff --git a/1.10/alpine3.7/Dockerfile b/1.10/alpine3.8/Dockerfile
index dee775b..49bb202 100644
--- a/1.10/alpine3.7/Dockerfile
+++ b/1.10/alpine3.8/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.8

 RUN apk add --no-cache \
                ca-certificates
```
```sh
$ git diff --no-index 1.11-rc/alpine3.7 1.11-rc/alpine3.8
```
```diff
diff --git a/1.11-rc/alpine3.7/Dockerfile b/1.11-rc/alpine3.8/Dockerfile
index 073ebed..7b985b7 100644
--- a/1.11-rc/alpine3.7/Dockerfile
+++ b/1.11-rc/alpine3.8/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.8

 RUN apk add --no-cache \
                ca-certificates
```