### PR TITLE
Add support for Windows Server 1809

### DIFF
--- a/1.10/windows/nanoserver-sac2016/Dockerfile
+++ b/1.10/windows/nanoserver-sac2016/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/nanoserver:sac2016
+FROM mcr.microsoft.com/windows/nanoserver:sac2016
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/1.10/windows/windowsservercore-1709/Dockerfile
+++ b/1.10/windows/windowsservercore-1709/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore:1709
+FROM mcr.microsoft.com/windows/servercore:1709
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/1.10/windows/windowsservercore-1803/Dockerfile
+++ b/1.10/windows/windowsservercore-1803/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore:1803
+FROM mcr.microsoft.com/windows/servercore:1803
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/1.10/windows/windowsservercore-1809/Dockerfile
+++ b/1.10/windows/windowsservercore-1809/Dockerfile
@@ -1,0 +1,73 @@
+FROM mcr.microsoft.com/windows/servercore:1809
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# install MinGit (especially for "go get")
+# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
+# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
+# "It currently requires only ~45MB on disk."
+ENV GIT_VERSION 2.11.1
+ENV GIT_TAG v${GIT_VERSION}.windows.1
+ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${GIT_TAG}/MinGit-${GIT_VERSION}-64-bit.zip
+ENV GIT_DOWNLOAD_SHA256 668d16a799dd721ed126cc91bed49eb2c072ba1b25b50048280a4e2c5ed56e59
+# steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
+RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:GIT_DOWNLOAD_URL -OutFile 'git.zip'; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_DOWNLOAD_SHA256); \
+	if ((Get-FileHash git.zip -Algorithm sha256).Hash -ne $env:GIT_DOWNLOAD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive -Path git.zip -DestinationPath C:\git\.; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item git.zip -Force; \
+	\
+	Write-Host 'Updating PATH ...'; \
+	$env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  git --version'; git --version; \
+	\
+	Write-Host 'Complete.';
+
+# ideally, this would be C:\go to match Linux a bit closer, but C:\go is the recommended install path for Go itself on Windows
+ENV GOPATH C:\\gopath
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
+# doing this first to share cache across versions more aggressively
+
+ENV GOLANG_VERSION 1.10.7
+
+RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSION); \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
+	\
+	$sha256 = '791e2d5a409932157ac87f4da7fa22d5e5468b784d5933121e4a747d89639e15'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
+	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive go.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Complete.';
+
+WORKDIR $GOPATH

--- a/1.10/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/1.10/windows/windowsservercore-ltsc2016/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore:ltsc2016
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/1.11/windows/nanoserver-sac2016/Dockerfile
+++ b/1.11/windows/nanoserver-sac2016/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/nanoserver:sac2016
+FROM mcr.microsoft.com/windows/nanoserver:sac2016
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/1.11/windows/windowsservercore-1709/Dockerfile
+++ b/1.11/windows/windowsservercore-1709/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore:1709
+FROM mcr.microsoft.com/windows/servercore:1709
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/1.11/windows/windowsservercore-1803/Dockerfile
+++ b/1.11/windows/windowsservercore-1803/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore:1803
+FROM mcr.microsoft.com/windows/servercore:1803
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/1.11/windows/windowsservercore-1809/Dockerfile
+++ b/1.11/windows/windowsservercore-1809/Dockerfile
@@ -1,0 +1,73 @@
+FROM mcr.microsoft.com/windows/servercore:1809
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# install MinGit (especially for "go get")
+# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
+# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
+# "It currently requires only ~45MB on disk."
+ENV GIT_VERSION 2.11.1
+ENV GIT_TAG v${GIT_VERSION}.windows.1
+ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${GIT_TAG}/MinGit-${GIT_VERSION}-64-bit.zip
+ENV GIT_DOWNLOAD_SHA256 668d16a799dd721ed126cc91bed49eb2c072ba1b25b50048280a4e2c5ed56e59
+# steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
+RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:GIT_DOWNLOAD_URL -OutFile 'git.zip'; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_DOWNLOAD_SHA256); \
+	if ((Get-FileHash git.zip -Algorithm sha256).Hash -ne $env:GIT_DOWNLOAD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive -Path git.zip -DestinationPath C:\git\.; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item git.zip -Force; \
+	\
+	Write-Host 'Updating PATH ...'; \
+	$env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  git --version'; git --version; \
+	\
+	Write-Host 'Complete.';
+
+# ideally, this would be C:\go to match Linux a bit closer, but C:\go is the recommended install path for Go itself on Windows
+ENV GOPATH C:\\gopath
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
+# doing this first to share cache across versions more aggressively
+
+ENV GOLANG_VERSION 1.11.4
+
+RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSION); \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
+	\
+	$sha256 = 'eeb20e21702f2b9469d9381df5de85e2f731b64a1f54effe196d0f7d0227fe14'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
+	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive go.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Complete.';
+
+WORKDIR $GOPATH

--- a/1.11/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/1.11/windows/windowsservercore-ltsc2016/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore:ltsc2016
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/1.12-rc/windows/nanoserver-sac2016/Dockerfile
+++ b/1.12-rc/windows/nanoserver-sac2016/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/nanoserver:sac2016
+FROM mcr.microsoft.com/windows/nanoserver:sac2016
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/1.12-rc/windows/windowsservercore-1709/Dockerfile
+++ b/1.12-rc/windows/windowsservercore-1709/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore:1709
+FROM mcr.microsoft.com/windows/servercore:1709
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/1.12-rc/windows/windowsservercore-1803/Dockerfile
+++ b/1.12-rc/windows/windowsservercore-1803/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore:1803
+FROM mcr.microsoft.com/windows/servercore:1803
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/1.12-rc/windows/windowsservercore-1809/Dockerfile
+++ b/1.12-rc/windows/windowsservercore-1809/Dockerfile
@@ -1,0 +1,73 @@
+FROM mcr.microsoft.com/windows/servercore:1809
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# install MinGit (especially for "go get")
+# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
+# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
+# "It currently requires only ~45MB on disk."
+ENV GIT_VERSION 2.11.1
+ENV GIT_TAG v${GIT_VERSION}.windows.1
+ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${GIT_TAG}/MinGit-${GIT_VERSION}-64-bit.zip
+ENV GIT_DOWNLOAD_SHA256 668d16a799dd721ed126cc91bed49eb2c072ba1b25b50048280a4e2c5ed56e59
+# steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
+RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:GIT_DOWNLOAD_URL -OutFile 'git.zip'; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_DOWNLOAD_SHA256); \
+	if ((Get-FileHash git.zip -Algorithm sha256).Hash -ne $env:GIT_DOWNLOAD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive -Path git.zip -DestinationPath C:\git\.; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item git.zip -Force; \
+	\
+	Write-Host 'Updating PATH ...'; \
+	$env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  git --version'; git --version; \
+	\
+	Write-Host 'Complete.';
+
+# ideally, this would be C:\go to match Linux a bit closer, but C:\go is the recommended install path for Go itself on Windows
+ENV GOPATH C:\\gopath
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
+# doing this first to share cache across versions more aggressively
+
+ENV GOLANG_VERSION 1.12beta1
+
+RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSION); \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
+	\
+	$sha256 = '167824d31e5a75a89e0ee159561042e144498f8f2cc725767277ccbcf749684b'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
+	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive go.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Complete.';
+
+WORKDIR $GOPATH

--- a/1.12-rc/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/1.12-rc/windows/windowsservercore-ltsc2016/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore:ltsc2016
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/Dockerfile-windows-nanoserver.template
+++ b/Dockerfile-windows-nanoserver.template
@@ -1,4 +1,4 @@
-FROM microsoft/nanoserver:%%MICROSOFT-TAG%%
+FROM mcr.microsoft.com/windows/nanoserver:%%MICROSOFT-TAG%%
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/Dockerfile-windows-windowsservercore.template
+++ b/Dockerfile-windows-windowsservercore.template
@@ -1,4 +1,4 @@
-FROM microsoft/windowsservercore:%%MICROSOFT-TAG%%
+FROM mcr.microsoft.com/windows/servercore:%%MICROSOFT-TAG%%
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -73,8 +73,8 @@ for version in "${versions[@]}"; do
 
 	for v in \
 		stretch alpine3.{8,7} \
-		windows/windowsservercore-{ltsc2016,1709,1803} \
-		windows/nanoserver-{sac2016,1709,1803} \
+		windows/windowsservercore-{ltsc2016,1709,1803,1809} \
+		windows/nanoserver-{sac2016,1709,1803,1809} \
 	; do
 		dir="$version/$v"
 

--- a/update.sh
+++ b/update.sh
@@ -106,8 +106,8 @@ for version in "${versions[@]}"; do
 	done
 
 	for winVariant in \
-		nanoserver-{sac2016,1709,1803} \
-		windowsservercore-{ltsc2016,1709,1803} \
+		nanoserver-{sac2016,1709,1803,1809} \
+		windowsservercore-{ltsc2016,1709,1803,1809} \
 	; do
 		if [ -d "$version/windows/$winVariant" ]; then
 			sed -r \
@@ -118,7 +118,7 @@ for version in "${versions[@]}"; do
 
 			case "$winVariant" in
 				*-1803) travisEnv='\n    - os: windows\n      dist: 1803-containers\n      env: VERSION='"$version VARIANT=windows/$winVariant$travisEnv" ;;
-				*-1709) ;; # no AppVeyor or Travis support for 1709: https://github.com/appveyor/ci/issues/1885
+				*-1709|*-1809) ;; # no AppVeyor or Travis support for 1709 or 1809: https://github.com/appveyor/ci/issues/1885 and https://github.com/appveyor/ci/issues/2676
 				*) appveyorEnv='\n    - version: '"$version"'\n      variant: '"$winVariant$appveyorEnv" ;;
 			esac
 		fi


### PR DESCRIPTION
Adding support for the new 1809 images, and following the base images to mcr.microsoft.com as described in the blog post here: https://azure.microsoft.com/en-us/blog/microsoft-syndicates-container-catalog/