### PR TITLE
Set GOCACHE and fix perms to avoid permissions errors

### DIFF
--- a/1.10/alpine3.7/Dockerfile
+++ b/1.10/alpine3.7/Dockerfile
@@ -54,11 +54,15 @@ RUN set -eux; \
 	apk del .build-deps; \
 	\
 	export PATH="/usr/local/go/bin:$PATH"; \
-	go version
+	go version; \
+	\
+	if [ ! -z "$(go env GOCACHE)" ]; then \
+		mkdir -p "$(go env GOCACHE)"; \
+		chmod -R 777 "$(go env GOCACHE)"; \
+	fi;
 
-ENV GOCACHE /.cache
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-RUN mkdir -p "$GOCACHE" "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" "$GOCACHE"
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH

--- a/1.10/alpine3.7/Dockerfile
+++ b/1.10/alpine3.7/Dockerfile
@@ -56,8 +56,9 @@ RUN set -eux; \
 	export PATH="/usr/local/go/bin:$PATH"; \
 	go version
 
+ENV GOCACHE /.cache
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+RUN mkdir -p "$GOCACHE" "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" "$GOCACHE"
 WORKDIR $GOPATH

--- a/1.10/alpine3.8/Dockerfile
+++ b/1.10/alpine3.8/Dockerfile
@@ -54,11 +54,15 @@ RUN set -eux; \
 	apk del .build-deps; \
 	\
 	export PATH="/usr/local/go/bin:$PATH"; \
-	go version
+	go version; \
+	\
+	if [ ! -z "$(go env GOCACHE)" ]; then \
+		mkdir -p "$(go env GOCACHE)"; \
+		chmod -R 777 "$(go env GOCACHE)"; \
+	fi;
 
-ENV GOCACHE /.cache
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-RUN mkdir -p "$GOCACHE" "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" "$GOCACHE"
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH

--- a/1.10/alpine3.8/Dockerfile
+++ b/1.10/alpine3.8/Dockerfile
@@ -56,8 +56,9 @@ RUN set -eux; \
 	export PATH="/usr/local/go/bin:$PATH"; \
 	go version
 
+ENV GOCACHE /.cache
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+RUN mkdir -p "$GOCACHE" "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" "$GOCACHE"
 WORKDIR $GOPATH

--- a/1.10/stretch/Dockerfile
+++ b/1.10/stretch/Dockerfile
@@ -41,11 +41,15 @@ RUN set -eux; \
 	fi; \
 	\
 	export PATH="/usr/local/go/bin:$PATH"; \
-	go version
+	go version; \
+	\
+	if [ ! -z "$(go env GOCACHE)" ]; then \
+		mkdir -p "$(go env GOCACHE)"; \
+		chmod -R 777 "$(go env GOCACHE)"; \
+	fi;
 
-ENV GOCACHE /.cache
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-RUN mkdir -p "$GOCACHE" "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" "$GOCACHE"
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH

--- a/1.10/stretch/Dockerfile
+++ b/1.10/stretch/Dockerfile
@@ -43,8 +43,9 @@ RUN set -eux; \
 	export PATH="/usr/local/go/bin:$PATH"; \
 	go version
 
+ENV GOCACHE /.cache
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+RUN mkdir -p "$GOCACHE" "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" "$GOCACHE"
 WORKDIR $GOPATH

--- a/1.11/alpine3.7/Dockerfile
+++ b/1.11/alpine3.7/Dockerfile
@@ -54,11 +54,15 @@ RUN set -eux; \
 	apk del .build-deps; \
 	\
 	export PATH="/usr/local/go/bin:$PATH"; \
-	go version
+	go version; \
+	\
+	if [ ! -z "$(go env GOCACHE)" ]; then \
+		mkdir -p "$(go env GOCACHE)"; \
+		chmod -R 777 "$(go env GOCACHE)"; \
+	fi;
 
-ENV GOCACHE /.cache
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-RUN mkdir -p "$GOCACHE" "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" "$GOCACHE"
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH

--- a/1.11/alpine3.7/Dockerfile
+++ b/1.11/alpine3.7/Dockerfile
@@ -56,8 +56,9 @@ RUN set -eux; \
 	export PATH="/usr/local/go/bin:$PATH"; \
 	go version
 
+ENV GOCACHE /.cache
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+RUN mkdir -p "$GOCACHE" "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" "$GOCACHE"
 WORKDIR $GOPATH

--- a/1.11/alpine3.8/Dockerfile
+++ b/1.11/alpine3.8/Dockerfile
@@ -54,11 +54,15 @@ RUN set -eux; \
 	apk del .build-deps; \
 	\
 	export PATH="/usr/local/go/bin:$PATH"; \
-	go version
+	go version; \
+	\
+	if [ ! -z "$(go env GOCACHE)" ]; then \
+		mkdir -p "$(go env GOCACHE)"; \
+		chmod -R 777 "$(go env GOCACHE)"; \
+	fi;
 
-ENV GOCACHE /.cache
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-RUN mkdir -p "$GOCACHE" "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" "$GOCACHE"
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH

--- a/1.11/alpine3.8/Dockerfile
+++ b/1.11/alpine3.8/Dockerfile
@@ -56,8 +56,9 @@ RUN set -eux; \
 	export PATH="/usr/local/go/bin:$PATH"; \
 	go version
 
+ENV GOCACHE /.cache
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+RUN mkdir -p "$GOCACHE" "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" "$GOCACHE"
 WORKDIR $GOPATH

--- a/1.11/stretch/Dockerfile
+++ b/1.11/stretch/Dockerfile
@@ -41,11 +41,15 @@ RUN set -eux; \
 	fi; \
 	\
 	export PATH="/usr/local/go/bin:$PATH"; \
-	go version
+	go version; \
+	\
+	if [ ! -z "$(go env GOCACHE)" ]; then \
+		mkdir -p "$(go env GOCACHE)"; \
+		chmod -R 777 "$(go env GOCACHE)"; \
+	fi;
 
-ENV GOCACHE /.cache
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-RUN mkdir -p "$GOCACHE" "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" "$GOCACHE"
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH

--- a/1.11/stretch/Dockerfile
+++ b/1.11/stretch/Dockerfile
@@ -43,8 +43,9 @@ RUN set -eux; \
 	export PATH="/usr/local/go/bin:$PATH"; \
 	go version
 
+ENV GOCACHE /.cache
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+RUN mkdir -p "$GOCACHE" "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" "$GOCACHE"
 WORKDIR $GOPATH

--- a/1.12-rc/alpine3.8/Dockerfile
+++ b/1.12-rc/alpine3.8/Dockerfile
@@ -54,11 +54,15 @@ RUN set -eux; \
 	apk del .build-deps; \
 	\
 	export PATH="/usr/local/go/bin:$PATH"; \
-	go version
+	go version; \
+	\
+	if [ ! -z "$(go env GOCACHE)" ]; then \
+		mkdir -p "$(go env GOCACHE)"; \
+		chmod -R 777 "$(go env GOCACHE)"; \
+	fi;
 
-ENV GOCACHE /.cache
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-RUN mkdir -p "$GOCACHE" "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" "$GOCACHE"
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH

--- a/1.12-rc/alpine3.8/Dockerfile
+++ b/1.12-rc/alpine3.8/Dockerfile
@@ -56,8 +56,9 @@ RUN set -eux; \
 	export PATH="/usr/local/go/bin:$PATH"; \
 	go version
 
+ENV GOCACHE /.cache
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+RUN mkdir -p "$GOCACHE" "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" "$GOCACHE"
 WORKDIR $GOPATH

--- a/1.12-rc/stretch/Dockerfile
+++ b/1.12-rc/stretch/Dockerfile
@@ -41,11 +41,15 @@ RUN set -eux; \
 	fi; \
 	\
 	export PATH="/usr/local/go/bin:$PATH"; \
-	go version
+	go version; \
+	\
+	if [ ! -z "$(go env GOCACHE)" ]; then \
+		mkdir -p "$(go env GOCACHE)"; \
+		chmod -R 777 "$(go env GOCACHE)"; \
+	fi;
 
-ENV GOCACHE /.cache
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-RUN mkdir -p "$GOCACHE" "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" "$GOCACHE"
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH

--- a/1.12-rc/stretch/Dockerfile
+++ b/1.12-rc/stretch/Dockerfile
@@ -43,8 +43,9 @@ RUN set -eux; \
 	export PATH="/usr/local/go/bin:$PATH"; \
 	go version
 
+ENV GOCACHE /.cache
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+RUN mkdir -p "$GOCACHE" "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" "$GOCACHE"
 WORKDIR $GOPATH

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -54,11 +54,15 @@ RUN set -eux; \
 	apk del .build-deps; \
 	\
 	export PATH="/usr/local/go/bin:$PATH"; \
-	go version
+	go version; \
+	\
+	if [ ! -z "$(go env GOCACHE)" ]; then \
+		mkdir -p "$(go env GOCACHE)"; \
+		chmod -R 777 "$(go env GOCACHE)"; \
+	fi;
 
-ENV GOCACHE /.cache
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-RUN mkdir -p "$GOCACHE" "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" "$GOCACHE"
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -56,8 +56,9 @@ RUN set -eux; \
 	export PATH="/usr/local/go/bin:$PATH"; \
 	go version
 
+ENV GOCACHE /.cache
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+RUN mkdir -p "$GOCACHE" "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" "$GOCACHE"
 WORKDIR $GOPATH

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -33,8 +33,9 @@ RUN set -eux; \
 	export PATH="/usr/local/go/bin:$PATH"; \
 	go version
 
+ENV GOCACHE /.cache
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+RUN mkdir -p "$GOCACHE" "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" "$GOCACHE"
 WORKDIR $GOPATH

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -31,11 +31,15 @@ RUN set -eux; \
 	fi; \
 	\
 	export PATH="/usr/local/go/bin:$PATH"; \
-	go version
+	go version; \
+	\
+	if [ ! -z "$(go env GOCACHE)" ]; then \
+		mkdir -p "$(go env GOCACHE)"; \
+		chmod -R 777 "$(go env GOCACHE)"; \
+	fi;
 
-ENV GOCACHE /.cache
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-RUN mkdir -p "$GOCACHE" "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" "$GOCACHE"
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH


### PR DESCRIPTION
On some CI environments like Jenkins, cache could not be used due to permission errors. Here is a simple POC with a pipeline stage :

```
stage("Test") {
  docker.image('golang:1.11.5').inside {
    sh '''
    go version
    go mod download
    go get -u github.com/jstemmer/go-junit-report
    go get -u github.com/t-yuki/gocover-cobertura
    go test -coverprofile=bin/coverage.out -v ./...
    go test -json ./... > bin/report.json
    go test -v ./... 2>&1 | go-junit-report > bin/junit.xml
    gocover-cobertura < bin/coverage.out > bin/cobertura.xml
    '''
  }
}
```

This stage leads to :

```
[Pipeline] sh
+ go version
go version go1.11.5 linux/amd64
+ go mod download
go: disabling cache (/.cache/go-build) due to initialization failure: mkdir /.cache: permission denied
go: cannot use modules with build cache disabled
[Pipeline] }
$ docker top b511f686685e39732d3aad9486a66380632397aafe1ca3bf6eb2ce918e0aeba3 -eo pid,comm
$ docker stop --time=1 b511f686685e39732d3aad9486a66380632397aafe1ca3bf6eb2ce918e0aeba3
$ docker rm -f b511f686685e39732d3aad9486a66380632397aafe1ca3bf6eb2ce918e0aeba3
```

My current workaround sets GOCACHE to /tmp :

```
stage("Test") {
  docker.image('golang:1.11.5').inside('-e "GOCACHE=/tmp"') { c ->
    sh '''
    go version
    go mod download
    go get -u github.com/jstemmer/go-junit-report
    go get -u github.com/t-yuki/gocover-cobertura
    go test -coverprofile=bin/coverage.out -v ./...
    go test -json ./... > bin/report.json
    go test -v ./... 2>&1 | go-junit-report > bin/junit.xml
    gocover-cobertura < bin/coverage.out > bin/cobertura.xml
    '''
  }
}
```