### PR TITLE
Add alpine 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
     - os: linux
       env: VERSION=1.12 VARIANT=stretch
     - os: linux
+      env: VERSION=1.12 VARIANT=alpine3.10
+    - os: linux
       env: VERSION=1.12 VARIANT=alpine3.9
     - os: windows
       dist: 1803-containers
@@ -16,9 +18,9 @@ matrix:
     - os: linux
       env: VERSION=1.11 VARIANT=stretch
     - os: linux
-      env: VERSION=1.11 VARIANT=alpine3.9
+      env: VERSION=1.11 VARIANT=alpine3.10
     - os: linux
-      env: VERSION=1.11 VARIANT=alpine3.8
+      env: VERSION=1.11 VARIANT=alpine3.9
 
 install:
   - git clone https://github.com/docker-library/official-images.git ~/official-images

--- a/1.11/alpine3.10/Dockerfile
+++ b/1.11/alpine3.10/Dockerfile
@@ -1,0 +1,63 @@
+FROM alpine:3.10
+
+RUN apk add --no-cache \
+		ca-certificates
+
+# set up nsswitch.conf for Go's "netgo" implementation
+# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+# - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
+ENV GOLANG_VERSION 1.11.11
+
+RUN set -eux; \
+	apk add --no-cache --virtual .build-deps \
+		bash \
+		gcc \
+		musl-dev \
+		openssl \
+		go \
+	; \
+	export \
+# set GOROOT_BOOTSTRAP such that we can actually build Go
+		GOROOT_BOOTSTRAP="$(go env GOROOT)" \
+# ... and set "cross-building" related vars to the installed system's values so that we create a build targeting the proper arch
+# (for example, if our build host is GOARCH=amd64, but our build env/image is GOARCH=386, our build needs GOARCH=386)
+		GOOS="$(go env GOOS)" \
+		GOARCH="$(go env GOARCH)" \
+		GOHOSTOS="$(go env GOHOSTOS)" \
+		GOHOSTARCH="$(go env GOHOSTARCH)" \
+	; \
+# also explicitly set GO386 and GOARM if appropriate
+# https://github.com/docker-library/golang/issues/184
+	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+		armhf) export GOARM='6' ;; \
+		x86) export GO386='387' ;; \
+	esac; \
+	\
+	wget -O go.tgz "https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz"; \
+	echo '1fff7c33ef2522e6dfaf6ab96ec4c2a8b76d018aae6fc88ce2bd40f2202d0f8c *go.tgz' | sha256sum -c -; \
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+	cd /usr/local/go/src; \
+	./make.bash; \
+	\
+	rm -rf \
+# https://github.com/golang/go/blob/0b30cf534a03618162d3015c8705dd2231e34703/src/cmd/dist/buildtool.go#L121-L125
+		/usr/local/go/pkg/bootstrap \
+# https://golang.org/cl/82095
+# https://github.com/golang/build/blob/e3fe1605c30f6a3fd136b561569933312ede8782/cmd/release/releaselet.go#L56
+		/usr/local/go/pkg/obj \
+	; \
+	apk del .build-deps; \
+	\
+	export PATH="/usr/local/go/bin:$PATH"; \
+	go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH

--- a/1.12/alpine3.10/Dockerfile
+++ b/1.12/alpine3.10/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.10
 
 RUN apk add --no-cache \
 		ca-certificates
@@ -8,7 +8,7 @@ RUN apk add --no-cache \
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
 RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 
-ENV GOLANG_VERSION 1.11.11
+ENV GOLANG_VERSION 1.12.6
 
 RUN set -eux; \
 	apk add --no-cache --virtual .build-deps \
@@ -37,7 +37,7 @@ RUN set -eux; \
 	esac; \
 	\
 	wget -O go.tgz "https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz"; \
-	echo '1fff7c33ef2522e6dfaf6ab96ec4c2a8b76d018aae6fc88ce2bd40f2202d0f8c *go.tgz' | sha256sum -c -; \
+	echo 'c96c5ccc7455638ae1a8b7498a030fe653731c8391c5f8e79590bce72f92b4ca *go.tgz' | sha256sum -c -; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
 	\

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -9,7 +9,7 @@ declare -A aliases=(
 defaultDebianSuite='stretch'
 declare -A debianSuite=(
 )
-defaultAlpineVersion='3.9'
+defaultAlpineVersion='3.10'
 declare -A alpineVersion=(
 	#[1.9]='3.7'
 )
@@ -72,7 +72,7 @@ for version in "${versions[@]}"; do
 	)
 
 	for v in \
-		stretch alpine{3.9,3.8} \
+		stretch alpine{3.10,3.9} \
 		windows/windowsservercore-{ltsc2016,1803,1809} \
 		windows/nanoserver-{1803,1809} \
 	; do

--- a/update.sh
+++ b/update.sh
@@ -84,7 +84,7 @@ for version in "${versions[@]}"; do
 	windowsSha256="$(curl -fsSL "https://storage.googleapis.com/golang/go${fullVersion}.windows-amd64.zip.sha256")"
 
 	for variant in \
-		alpine{3.8,3.9} \
+		alpine{3.9,3.10} \
 		stretch \
 	; do
 		if [ -d "$version/$variant" ]; then


### PR DESCRIPTION
I based my self on previous PR. I hope, I didn't miss a step.

It should:
- add golang:1.12-alpine3.10
- add golang:1.11-alpine3.10
- remove golang:1.11-alpine3.8
- set alpine 3.10 as default for alpine base.

Release note: https://alpinelinux.org/posts/Alpine-3.10.0-released.html