### PR TITLE
Add Go 1.13

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,6 +3,8 @@ image: Visual Studio 2017
 
 environment:
   matrix:
+    - version: 1.13-rc
+      variant: windowsservercore-ltsc2016
     - version: 1.12
       variant: windowsservercore-ltsc2016
     - version: 1.11

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,13 @@ matrix:
   include:
     - os: windows
       dist: 1803-containers
+      env: VERSION=1.13-rc VARIANT=windows/windowsservercore-1803
+    - os: linux
+      env: VERSION=1.13-rc VARIANT=buster
+    - os: linux
+      env: VERSION=1.13-rc VARIANT=alpine3.10
+    - os: windows
+      dist: 1803-containers
       env: VERSION=1.12 VARIANT=windows/windowsservercore-1803
     - os: linux
       env: VERSION=1.12 VARIANT=stretch

--- a/1.13-rc/alpine3.10/Dockerfile
+++ b/1.13-rc/alpine3.10/Dockerfile
@@ -1,0 +1,63 @@
+FROM alpine:3.10
+
+RUN apk add --no-cache \
+		ca-certificates
+
+# set up nsswitch.conf for Go's "netgo" implementation
+# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+# - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
+ENV GOLANG_VERSION 1.13beta1
+
+RUN set -eux; \
+	apk add --no-cache --virtual .build-deps \
+		bash \
+		gcc \
+		musl-dev \
+		openssl \
+		go \
+	; \
+	export \
+# set GOROOT_BOOTSTRAP such that we can actually build Go
+		GOROOT_BOOTSTRAP="$(go env GOROOT)" \
+# ... and set "cross-building" related vars to the installed system's values so that we create a build targeting the proper arch
+# (for example, if our build host is GOARCH=amd64, but our build env/image is GOARCH=386, our build needs GOARCH=386)
+		GOOS="$(go env GOOS)" \
+		GOARCH="$(go env GOARCH)" \
+		GOHOSTOS="$(go env GOHOSTOS)" \
+		GOHOSTARCH="$(go env GOHOSTARCH)" \
+	; \
+# also explicitly set GO386 and GOARM if appropriate
+# https://github.com/docker-library/golang/issues/184
+	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+		armhf) export GOARM='6' ;; \
+		x86) export GO386='387' ;; \
+	esac; \
+	\
+	wget -O go.tgz "https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz"; \
+	echo 'e8a7c504cd6775b8a6af101158b8871455918c9a61162f0180f7a9f118dc4102 *go.tgz' | sha256sum -c -; \
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+	cd /usr/local/go/src; \
+	./make.bash; \
+	\
+	rm -rf \
+# https://github.com/golang/go/blob/0b30cf534a03618162d3015c8705dd2231e34703/src/cmd/dist/buildtool.go#L121-L125
+		/usr/local/go/pkg/bootstrap \
+# https://golang.org/cl/82095
+# https://github.com/golang/build/blob/e3fe1605c30f6a3fd136b561569933312ede8782/cmd/release/releaselet.go#L56
+		/usr/local/go/pkg/obj \
+	; \
+	apk del .build-deps; \
+	\
+	export PATH="/usr/local/go/bin:$PATH"; \
+	go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH

--- a/1.13-rc/buster/Dockerfile
+++ b/1.13-rc/buster/Dockerfile
@@ -1,0 +1,50 @@
+FROM buildpack-deps:buster-scm
+
+# gcc for cgo
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		g++ \
+		gcc \
+		libc6-dev \
+		make \
+		pkg-config \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV GOLANG_VERSION 1.13beta1
+
+RUN set -eux; \
+	\
+# this "case" statement is generated via "update.sh"
+	dpkgArch="$(dpkg --print-architecture)"; \
+	case "${dpkgArch##*-}" in \
+		amd64) goRelArch='linux-amd64'; goRelSha256='dbd131c92f381a5bc5ca1f0cfd942cb8be7d537007b6f412b5be41ff38a7d0d9' ;; \
+		armhf) goRelArch='linux-armv6l'; goRelSha256='77993f1dce5b4d080cbd06a4553e5e1c6caa7ad6817ea3c62254b89d6f079504' ;; \
+		arm64) goRelArch='linux-arm64'; goRelSha256='298a325d8eeba561a26312a9cdc821a96873c10fca7f48a7f98bbd8848bd8bd4' ;; \
+		i386) goRelArch='linux-386'; goRelSha256='38039e4f7b6eea8f55e91d90607150d5d397f9063c06445c45009dd1e6dba8cc' ;; \
+		ppc64el) goRelArch='linux-ppc64le'; goRelSha256='0f3c5c7b7956911ed8d1fc4e9dbeb2584d0be695c5c15b528422e3bb2d5989f0' ;; \
+		s390x) goRelArch='linux-s390x'; goRelSha256='877065ac7d1729e5de1bbfe1e712788bf9dee5613a5502cf0ba76e65c2521b26' ;; \
+		*) goRelArch='src'; goRelSha256='e8a7c504cd6775b8a6af101158b8871455918c9a61162f0180f7a9f118dc4102'; \
+			echo >&2; echo >&2 "warning: current architecture ($dpkgArch) does not have a corresponding Go binary release; will be building from source"; echo >&2 ;; \
+	esac; \
+	\
+	url="https://golang.org/dl/go${GOLANG_VERSION}.${goRelArch}.tar.gz"; \
+	wget -O go.tgz "$url"; \
+	echo "${goRelSha256} *go.tgz" | sha256sum -c -; \
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+	if [ "$goRelArch" = 'src' ]; then \
+		echo >&2; \
+		echo >&2 'error: UNIMPLEMENTED'; \
+		echo >&2 'TODO install golang-any from jessie-backports for GOROOT_BOOTSTRAP (and uninstall after build)'; \
+		echo >&2; \
+		exit 1; \
+	fi; \
+	\
+	export PATH="/usr/local/go/bin:$PATH"; \
+	go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH

--- a/1.13-rc/release-architectures
+++ b/1.13-rc/release-architectures
@@ -1,0 +1,9 @@
+# see https://golang.org/dl/
+
+# bashbrew-arch dpkg-arch golang-release-arch
+amd64   amd64   amd64
+arm32v7 armhf   armv6l
+arm64v8 arm64   arm64
+i386    i386    386
+ppc64le ppc64el ppc64le
+s390x   s390x   s390x

--- a/1.13-rc/windows/windowsservercore-1803/Dockerfile
+++ b/1.13-rc/windows/windowsservercore-1803/Dockerfile
@@ -1,0 +1,73 @@
+FROM mcr.microsoft.com/windows/servercore:1803
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# install MinGit (especially for "go get")
+# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
+# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
+# "It currently requires only ~45MB on disk."
+ENV GIT_VERSION 2.11.1
+ENV GIT_TAG v${GIT_VERSION}.windows.1
+ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${GIT_TAG}/MinGit-${GIT_VERSION}-64-bit.zip
+ENV GIT_DOWNLOAD_SHA256 668d16a799dd721ed126cc91bed49eb2c072ba1b25b50048280a4e2c5ed56e59
+# steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
+RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:GIT_DOWNLOAD_URL -OutFile 'git.zip'; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_DOWNLOAD_SHA256); \
+	if ((Get-FileHash git.zip -Algorithm sha256).Hash -ne $env:GIT_DOWNLOAD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive -Path git.zip -DestinationPath C:\git\.; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item git.zip -Force; \
+	\
+	Write-Host 'Updating PATH ...'; \
+	$env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  git --version'; git --version; \
+	\
+	Write-Host 'Complete.';
+
+# ideally, this would be C:\go to match Linux a bit closer, but C:\go is the recommended install path for Go itself on Windows
+ENV GOPATH C:\\gopath
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
+# doing this first to share cache across versions more aggressively
+
+ENV GOLANG_VERSION 1.13beta1
+
+RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSION); \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
+	\
+	$sha256 = '08098b4b0e1a105971d2fced2842e806f8ffa08973ae8781fd22dd90f76404fb'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
+	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive go.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Complete.';
+
+WORKDIR $GOPATH

--- a/1.13-rc/windows/windowsservercore-1809/Dockerfile
+++ b/1.13-rc/windows/windowsservercore-1809/Dockerfile
@@ -1,0 +1,73 @@
+FROM mcr.microsoft.com/windows/servercore:1809
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# install MinGit (especially for "go get")
+# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
+# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
+# "It currently requires only ~45MB on disk."
+ENV GIT_VERSION 2.11.1
+ENV GIT_TAG v${GIT_VERSION}.windows.1
+ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${GIT_TAG}/MinGit-${GIT_VERSION}-64-bit.zip
+ENV GIT_DOWNLOAD_SHA256 668d16a799dd721ed126cc91bed49eb2c072ba1b25b50048280a4e2c5ed56e59
+# steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
+RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:GIT_DOWNLOAD_URL -OutFile 'git.zip'; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_DOWNLOAD_SHA256); \
+	if ((Get-FileHash git.zip -Algorithm sha256).Hash -ne $env:GIT_DOWNLOAD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive -Path git.zip -DestinationPath C:\git\.; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item git.zip -Force; \
+	\
+	Write-Host 'Updating PATH ...'; \
+	$env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  git --version'; git --version; \
+	\
+	Write-Host 'Complete.';
+
+# ideally, this would be C:\go to match Linux a bit closer, but C:\go is the recommended install path for Go itself on Windows
+ENV GOPATH C:\\gopath
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
+# doing this first to share cache across versions more aggressively
+
+ENV GOLANG_VERSION 1.13beta1
+
+RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSION); \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
+	\
+	$sha256 = '08098b4b0e1a105971d2fced2842e806f8ffa08973ae8781fd22dd90f76404fb'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
+	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive go.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Complete.';
+
+WORKDIR $GOPATH

--- a/1.13-rc/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/1.13-rc/windows/windowsservercore-ltsc2016/Dockerfile
@@ -1,0 +1,73 @@
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# install MinGit (especially for "go get")
+# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
+# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
+# "It currently requires only ~45MB on disk."
+ENV GIT_VERSION 2.11.1
+ENV GIT_TAG v${GIT_VERSION}.windows.1
+ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${GIT_TAG}/MinGit-${GIT_VERSION}-64-bit.zip
+ENV GIT_DOWNLOAD_SHA256 668d16a799dd721ed126cc91bed49eb2c072ba1b25b50048280a4e2c5ed56e59
+# steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
+RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:GIT_DOWNLOAD_URL -OutFile 'git.zip'; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_DOWNLOAD_SHA256); \
+	if ((Get-FileHash git.zip -Algorithm sha256).Hash -ne $env:GIT_DOWNLOAD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive -Path git.zip -DestinationPath C:\git\.; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item git.zip -Force; \
+	\
+	Write-Host 'Updating PATH ...'; \
+	$env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ...'; \
+	Write-Host '  git --version'; git --version; \
+	\
+	Write-Host 'Complete.';
+
+# ideally, this would be C:\go to match Linux a bit closer, but C:\go is the recommended install path for Go itself on Windows
+ENV GOPATH C:\\gopath
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
+# doing this first to share cache across versions more aggressively
+
+ENV GOLANG_VERSION 1.13beta1
+
+RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSION); \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
+	\
+	$sha256 = '08098b4b0e1a105971d2fced2842e806f8ffa08973ae8781fd22dd90f76404fb'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
+	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive go.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Complete.';
+
+WORKDIR $GOPATH

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -6,8 +6,9 @@ declare -A aliases=(
 	[1.13-rc]='rc'
 )
 
-defaultDebianSuite='stretch'
+defaultDebianSuite='stretch' # TODO buster
 declare -A debianSuite=(
+	[1.13-rc]='buster'
 )
 defaultAlpineVersion='3.10'
 declare -A alpineVersion=(
@@ -72,7 +73,7 @@ for version in "${versions[@]}"; do
 	)
 
 	for v in \
-		stretch alpine{3.10,3.9} \
+		buster stretch alpine{3.10,3.9} \
 		windows/windowsservercore-{ltsc2016,1803,1809} \
 		windows/nanoserver-{1803,1809} \
 	; do

--- a/update.sh
+++ b/update.sh
@@ -85,7 +85,7 @@ for version in "${versions[@]}"; do
 
 	for variant in \
 		alpine{3.9,3.10} \
-		stretch \
+		stretch buster \
 	; do
 		if [ -d "$version/$variant" ]; then
 			tag="$variant"


### PR DESCRIPTION
This replaces Stretch with Buster given that Buster is scheduled to be released July 6th and Go 1.13 is scheduled to be released August 1st -- we'll adjust if Buster is delayed or Go 1.13's release is pushed up for some reason.