### PR TITLE
Update to golang 1.11.13 and 1.12.8

### DIFF
--- a/1.11/alpine3.10/Dockerfile
+++ b/1.11/alpine3.10/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache \
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
 RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 
-ENV GOLANG_VERSION 1.11.12
+ENV GOLANG_VERSION 1.11.13
 
 RUN set -eux; \
 	apk add --no-cache --virtual .build-deps \
@@ -37,7 +37,7 @@ RUN set -eux; \
 	esac; \
 	\
 	wget -O go.tgz "https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz"; \
-	echo '6d7a5ba05476609a7614af3292f29c3be06327503c1f1fdc02ef417870fd6926 *go.tgz' | sha256sum -c -; \
+	echo '5032095fd3f641cafcce164f551e5ae873785ce7b07ca7c143aecd18f7ba4076 *go.tgz' | sha256sum -c -; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
 	\

--- a/1.11/alpine3.9/Dockerfile
+++ b/1.11/alpine3.9/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache \
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
 RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 
-ENV GOLANG_VERSION 1.11.12
+ENV GOLANG_VERSION 1.11.13
 
 RUN set -eux; \
 	apk add --no-cache --virtual .build-deps \
@@ -37,7 +37,7 @@ RUN set -eux; \
 	esac; \
 	\
 	wget -O go.tgz "https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz"; \
-	echo '6d7a5ba05476609a7614af3292f29c3be06327503c1f1fdc02ef417870fd6926 *go.tgz' | sha256sum -c -; \
+	echo '5032095fd3f641cafcce164f551e5ae873785ce7b07ca7c143aecd18f7ba4076 *go.tgz' | sha256sum -c -; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
 	\

--- a/1.11/buster/Dockerfile
+++ b/1.11/buster/Dockerfile
@@ -9,20 +9,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		pkg-config \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION 1.11.12
+ENV GOLANG_VERSION 1.11.13
 
 RUN set -eux; \
 	\
 # this "case" statement is generated via "update.sh"
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "${dpkgArch##*-}" in \
-		amd64) goRelArch='linux-amd64'; goRelSha256='14ec881815eb9e6618f95df5eb385d961283efc196d97912595ba6484a56180d' ;; \
-		armhf) goRelArch='linux-armv6l'; goRelSha256='5ffe422dc054909da4e468cb0df6e2cd41cebfe4fd9515f32bb3e3fbfc416016' ;; \
-		arm64) goRelArch='linux-arm64'; goRelSha256='d79c075773fc3121d0e719b83b46115efff685ade94545a52f3ac22f43d76196' ;; \
-		i386) goRelArch='linux-386'; goRelSha256='8467e68d6ed6f6a95c6db6a1e352fc529f256bba0955eaef472e50cf4c0cba61' ;; \
-		ppc64el) goRelArch='linux-ppc64le'; goRelSha256='92bd4dc0dc8227fb22ad88545dd72669923019760cd640d4cca189860870561a' ;; \
-		s390x) goRelArch='linux-s390x'; goRelSha256='a4d100a1c92e50fd9b8a4d529da0ef0f4509c72643d6fb481918fd543f5871c0' ;; \
-		*) goRelArch='src'; goRelSha256='6d7a5ba05476609a7614af3292f29c3be06327503c1f1fdc02ef417870fd6926'; \
+		amd64) goRelArch='linux-amd64'; goRelSha256='50fe8e13592f8cf22304b9c4adfc11849a2c3d281b1d7e09c924ae24874c6daa' ;; \
+		armhf) goRelArch='linux-armv6l'; goRelSha256='513eb46158917662e1588cb89f51d11839730e46847778646c36c69c687bfdc5' ;; \
+		arm64) goRelArch='linux-arm64'; goRelSha256='e94329c97b38b5bffe9c18e84e9f521dc995e02df7696897a7626293da9ac593' ;; \
+		i386) goRelArch='linux-386'; goRelSha256='282e20167a7aaaba7b23de980696e1944a004efd0079e80d675d66b263ef595b' ;; \
+		ppc64el) goRelArch='linux-ppc64le'; goRelSha256='ad3c7397ddd41a5af9d9bf3c560d3d0f8c1bdef4ac4d21819a021ea88e25efca' ;; \
+		s390x) goRelArch='linux-s390x'; goRelSha256='bd00bd27e641450f165a37a83f1e83a4ef3c626ef5675b77184e9c0147257657' ;; \
+		*) goRelArch='src'; goRelSha256='5032095fd3f641cafcce164f551e5ae873785ce7b07ca7c143aecd18f7ba4076'; \
 			echo >&2; echo >&2 "warning: current architecture ($dpkgArch) does not have a corresponding Go binary release; will be building from source"; echo >&2 ;; \
 	esac; \
 	\

--- a/1.11/stretch/Dockerfile
+++ b/1.11/stretch/Dockerfile
@@ -9,20 +9,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		pkg-config \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION 1.11.12
+ENV GOLANG_VERSION 1.11.13
 
 RUN set -eux; \
 	\
 # this "case" statement is generated via "update.sh"
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "${dpkgArch##*-}" in \
-		amd64) goRelArch='linux-amd64'; goRelSha256='14ec881815eb9e6618f95df5eb385d961283efc196d97912595ba6484a56180d' ;; \
-		armhf) goRelArch='linux-armv6l'; goRelSha256='5ffe422dc054909da4e468cb0df6e2cd41cebfe4fd9515f32bb3e3fbfc416016' ;; \
-		arm64) goRelArch='linux-arm64'; goRelSha256='d79c075773fc3121d0e719b83b46115efff685ade94545a52f3ac22f43d76196' ;; \
-		i386) goRelArch='linux-386'; goRelSha256='8467e68d6ed6f6a95c6db6a1e352fc529f256bba0955eaef472e50cf4c0cba61' ;; \
-		ppc64el) goRelArch='linux-ppc64le'; goRelSha256='92bd4dc0dc8227fb22ad88545dd72669923019760cd640d4cca189860870561a' ;; \
-		s390x) goRelArch='linux-s390x'; goRelSha256='a4d100a1c92e50fd9b8a4d529da0ef0f4509c72643d6fb481918fd543f5871c0' ;; \
-		*) goRelArch='src'; goRelSha256='6d7a5ba05476609a7614af3292f29c3be06327503c1f1fdc02ef417870fd6926'; \
+		amd64) goRelArch='linux-amd64'; goRelSha256='50fe8e13592f8cf22304b9c4adfc11849a2c3d281b1d7e09c924ae24874c6daa' ;; \
+		armhf) goRelArch='linux-armv6l'; goRelSha256='513eb46158917662e1588cb89f51d11839730e46847778646c36c69c687bfdc5' ;; \
+		arm64) goRelArch='linux-arm64'; goRelSha256='e94329c97b38b5bffe9c18e84e9f521dc995e02df7696897a7626293da9ac593' ;; \
+		i386) goRelArch='linux-386'; goRelSha256='282e20167a7aaaba7b23de980696e1944a004efd0079e80d675d66b263ef595b' ;; \
+		ppc64el) goRelArch='linux-ppc64le'; goRelSha256='ad3c7397ddd41a5af9d9bf3c560d3d0f8c1bdef4ac4d21819a021ea88e25efca' ;; \
+		s390x) goRelArch='linux-s390x'; goRelSha256='bd00bd27e641450f165a37a83f1e83a4ef3c626ef5675b77184e9c0147257657' ;; \
+		*) goRelArch='src'; goRelSha256='5032095fd3f641cafcce164f551e5ae873785ce7b07ca7c143aecd18f7ba4076'; \
 			echo >&2; echo >&2 "warning: current architecture ($dpkgArch) does not have a corresponding Go binary release; will be building from source"; echo >&2 ;; \
 	esac; \
 	\

--- a/1.11/windows/nanoserver-1803/Dockerfile
+++ b/1.11/windows/nanoserver-1803/Dockerfile
@@ -14,9 +14,9 @@ RUN setx /m PATH "%GOPATH%\bin;C:\go\bin;%PATH%"
 USER ContainerUser
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.11.12
+ENV GOLANG_VERSION 1.11.13
 
-COPY --from=golang:1.11.12-windowsservercore-1803 C:\\go C:\\go
+COPY --from=golang:1.11.13-windowsservercore-1803 C:\\go C:\\go
 RUN go version
 
 WORKDIR $GOPATH

--- a/1.11/windows/nanoserver-1809/Dockerfile
+++ b/1.11/windows/nanoserver-1809/Dockerfile
@@ -14,9 +14,9 @@ RUN setx /m PATH "%GOPATH%\bin;C:\go\bin;%PATH%"
 USER ContainerUser
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.11.12
+ENV GOLANG_VERSION 1.11.13
 
-COPY --from=golang:1.11.12-windowsservercore-1809 C:\\go C:\\go
+COPY --from=golang:1.11.13-windowsservercore-1809 C:\\go C:\\go
 RUN go version
 
 WORKDIR $GOPATH

--- a/1.11/windows/windowsservercore-1803/Dockerfile
+++ b/1.11/windows/windowsservercore-1803/Dockerfile
@@ -46,13 +46,13 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.11.12
+ENV GOLANG_VERSION 1.11.13
 
 RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = 'a86e41e06d39f68ea8fa6a7765ce529abe3ec5037ba3a3bff2e6d25455a4fa34'; \
+	$sha256 = '55752de84439d0ed744ad681ae0915314516e69091fb86cab9701628ce3a65ff'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/1.11/windows/windowsservercore-1809/Dockerfile
+++ b/1.11/windows/windowsservercore-1809/Dockerfile
@@ -46,13 +46,13 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.11.12
+ENV GOLANG_VERSION 1.11.13
 
 RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = 'a86e41e06d39f68ea8fa6a7765ce529abe3ec5037ba3a3bff2e6d25455a4fa34'; \
+	$sha256 = '55752de84439d0ed744ad681ae0915314516e69091fb86cab9701628ce3a65ff'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/1.11/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/1.11/windows/windowsservercore-ltsc2016/Dockerfile
@@ -46,13 +46,13 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.11.12
+ENV GOLANG_VERSION 1.11.13
 
 RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = 'a86e41e06d39f68ea8fa6a7765ce529abe3ec5037ba3a3bff2e6d25455a4fa34'; \
+	$sha256 = '55752de84439d0ed744ad681ae0915314516e69091fb86cab9701628ce3a65ff'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/1.12/alpine3.10/Dockerfile
+++ b/1.12/alpine3.10/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache \
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
 RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 
-ENV GOLANG_VERSION 1.12.7
+ENV GOLANG_VERSION 1.12.8
 
 RUN set -eux; \
 	apk add --no-cache --virtual .build-deps \
@@ -37,7 +37,7 @@ RUN set -eux; \
 	esac; \
 	\
 	wget -O go.tgz "https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz"; \
-	echo '95e8447d6f04b8d6a62de1726defbb20ab203208ee167ed15f83d7978ce43b13 *go.tgz' | sha256sum -c -; \
+	echo '11ad2e2e31ff63fcf8a2bdffbe9bfa2e1845653358daed593c8c2d03453c9898 *go.tgz' | sha256sum -c -; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
 	\

--- a/1.12/alpine3.9/Dockerfile
+++ b/1.12/alpine3.9/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache \
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
 RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 
-ENV GOLANG_VERSION 1.12.7
+ENV GOLANG_VERSION 1.12.8
 
 RUN set -eux; \
 	apk add --no-cache --virtual .build-deps \
@@ -37,7 +37,7 @@ RUN set -eux; \
 	esac; \
 	\
 	wget -O go.tgz "https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz"; \
-	echo '95e8447d6f04b8d6a62de1726defbb20ab203208ee167ed15f83d7978ce43b13 *go.tgz' | sha256sum -c -; \
+	echo '11ad2e2e31ff63fcf8a2bdffbe9bfa2e1845653358daed593c8c2d03453c9898 *go.tgz' | sha256sum -c -; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
 	\

--- a/1.12/buster/Dockerfile
+++ b/1.12/buster/Dockerfile
@@ -9,20 +9,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		pkg-config \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION 1.12.7
+ENV GOLANG_VERSION 1.12.8
 
 RUN set -eux; \
 	\
 # this "case" statement is generated via "update.sh"
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "${dpkgArch##*-}" in \
-		amd64) goRelArch='linux-amd64'; goRelSha256='66d83bfb5a9ede000e33c6579a91a29e6b101829ad41fffb5c5bb6c900e109d9' ;; \
-		armhf) goRelArch='linux-armv6l'; goRelSha256='48edbe936e9eb74f259bfc4b621fafca4d4ec43156b4ee7bd0d979f257dcd60a' ;; \
-		arm64) goRelArch='linux-arm64'; goRelSha256='4da1f7198a8fa0c4067852656b6c10153a4eca5a26aca28ef02ae9f4a7939ba5' ;; \
-		i386) goRelArch='linux-386'; goRelSha256='ae2424b7ff557a708be12d3141f25b645966489ca49af1ad10b4fbe4c97d4c41' ;; \
-		ppc64el) goRelArch='linux-ppc64le'; goRelSha256='8eda20600d90247efbfa70d116d80056e11192d62592240975b2a8c53caa5bf3' ;; \
-		s390x) goRelArch='linux-s390x'; goRelSha256='3374ac3d646555e50be790091b51849319cfcb176904048458c7f4252337fce8' ;; \
-		*) goRelArch='src'; goRelSha256='95e8447d6f04b8d6a62de1726defbb20ab203208ee167ed15f83d7978ce43b13'; \
+		amd64) goRelArch='linux-amd64'; goRelSha256='bd26cd4962a362ed3c11835bca32c2e131c2ae050304f2c4df9fa6ded8db85d2' ;; \
+		armhf) goRelArch='linux-armv6l'; goRelSha256='b6b057e7b5c740894132ce30e70503d7d36988dcd61a00f0865d1e7d6dcc74ca' ;; \
+		arm64) goRelArch='linux-arm64'; goRelSha256='15e9e0b5b414d1a0322896368c0050af6ab1cd82d050e93f8eceb38ef2626652' ;; \
+		i386) goRelArch='linux-386'; goRelSha256='be164c4e04205c4fc713e81594bc2fdd4c94dff3d567ec8e0072223dd0778287' ;; \
+		ppc64el) goRelArch='linux-ppc64le'; goRelSha256='24a65f8a702ade1854f86ddf96eda554a8abd89c8a54ddc32788769419e90232' ;; \
+		s390x) goRelArch='linux-s390x'; goRelSha256='db78fc8f9610cb27ac35aab55cb11698f4daa2101acdf46f0ba64e1db16323e5' ;; \
+		*) goRelArch='src'; goRelSha256='11ad2e2e31ff63fcf8a2bdffbe9bfa2e1845653358daed593c8c2d03453c9898'; \
 			echo >&2; echo >&2 "warning: current architecture ($dpkgArch) does not have a corresponding Go binary release; will be building from source"; echo >&2 ;; \
 	esac; \
 	\

--- a/1.12/stretch/Dockerfile
+++ b/1.12/stretch/Dockerfile
@@ -9,20 +9,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		pkg-config \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION 1.12.7
+ENV GOLANG_VERSION 1.12.8
 
 RUN set -eux; \
 	\
 # this "case" statement is generated via "update.sh"
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "${dpkgArch##*-}" in \
-		amd64) goRelArch='linux-amd64'; goRelSha256='66d83bfb5a9ede000e33c6579a91a29e6b101829ad41fffb5c5bb6c900e109d9' ;; \
-		armhf) goRelArch='linux-armv6l'; goRelSha256='48edbe936e9eb74f259bfc4b621fafca4d4ec43156b4ee7bd0d979f257dcd60a' ;; \
-		arm64) goRelArch='linux-arm64'; goRelSha256='4da1f7198a8fa0c4067852656b6c10153a4eca5a26aca28ef02ae9f4a7939ba5' ;; \
-		i386) goRelArch='linux-386'; goRelSha256='ae2424b7ff557a708be12d3141f25b645966489ca49af1ad10b4fbe4c97d4c41' ;; \
-		ppc64el) goRelArch='linux-ppc64le'; goRelSha256='8eda20600d90247efbfa70d116d80056e11192d62592240975b2a8c53caa5bf3' ;; \
-		s390x) goRelArch='linux-s390x'; goRelSha256='3374ac3d646555e50be790091b51849319cfcb176904048458c7f4252337fce8' ;; \
-		*) goRelArch='src'; goRelSha256='95e8447d6f04b8d6a62de1726defbb20ab203208ee167ed15f83d7978ce43b13'; \
+		amd64) goRelArch='linux-amd64'; goRelSha256='bd26cd4962a362ed3c11835bca32c2e131c2ae050304f2c4df9fa6ded8db85d2' ;; \
+		armhf) goRelArch='linux-armv6l'; goRelSha256='b6b057e7b5c740894132ce30e70503d7d36988dcd61a00f0865d1e7d6dcc74ca' ;; \
+		arm64) goRelArch='linux-arm64'; goRelSha256='15e9e0b5b414d1a0322896368c0050af6ab1cd82d050e93f8eceb38ef2626652' ;; \
+		i386) goRelArch='linux-386'; goRelSha256='be164c4e04205c4fc713e81594bc2fdd4c94dff3d567ec8e0072223dd0778287' ;; \
+		ppc64el) goRelArch='linux-ppc64le'; goRelSha256='24a65f8a702ade1854f86ddf96eda554a8abd89c8a54ddc32788769419e90232' ;; \
+		s390x) goRelArch='linux-s390x'; goRelSha256='db78fc8f9610cb27ac35aab55cb11698f4daa2101acdf46f0ba64e1db16323e5' ;; \
+		*) goRelArch='src'; goRelSha256='11ad2e2e31ff63fcf8a2bdffbe9bfa2e1845653358daed593c8c2d03453c9898'; \
 			echo >&2; echo >&2 "warning: current architecture ($dpkgArch) does not have a corresponding Go binary release; will be building from source"; echo >&2 ;; \
 	esac; \
 	\

--- a/1.12/windows/nanoserver-1803/Dockerfile
+++ b/1.12/windows/nanoserver-1803/Dockerfile
@@ -14,9 +14,9 @@ RUN setx /m PATH "%GOPATH%\bin;C:\go\bin;%PATH%"
 USER ContainerUser
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.12.7
+ENV GOLANG_VERSION 1.12.8
 
-COPY --from=golang:1.12.7-windowsservercore-1803 C:\\go C:\\go
+COPY --from=golang:1.12.8-windowsservercore-1803 C:\\go C:\\go
 RUN go version
 
 WORKDIR $GOPATH

--- a/1.12/windows/nanoserver-1809/Dockerfile
+++ b/1.12/windows/nanoserver-1809/Dockerfile
@@ -14,9 +14,9 @@ RUN setx /m PATH "%GOPATH%\bin;C:\go\bin;%PATH%"
 USER ContainerUser
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.12.7
+ENV GOLANG_VERSION 1.12.8
 
-COPY --from=golang:1.12.7-windowsservercore-1809 C:\\go C:\\go
+COPY --from=golang:1.12.8-windowsservercore-1809 C:\\go C:\\go
 RUN go version
 
 WORKDIR $GOPATH

--- a/1.12/windows/windowsservercore-1803/Dockerfile
+++ b/1.12/windows/windowsservercore-1803/Dockerfile
@@ -46,13 +46,13 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.12.7
+ENV GOLANG_VERSION 1.12.8
 
 RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '502712c0e29edc6b9cda6fa5e4b6ff9b36e27d225373baead8708c9634aa8e50'; \
+	$sha256 = '4352ed90240ddc1b6379adf3210b849b8e89a173ca00616f2beff53df9fef3c8'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/1.12/windows/windowsservercore-1809/Dockerfile
+++ b/1.12/windows/windowsservercore-1809/Dockerfile
@@ -46,13 +46,13 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.12.7
+ENV GOLANG_VERSION 1.12.8
 
 RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '502712c0e29edc6b9cda6fa5e4b6ff9b36e27d225373baead8708c9634aa8e50'; \
+	$sha256 = '4352ed90240ddc1b6379adf3210b849b8e89a173ca00616f2beff53df9fef3c8'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \

--- a/1.12/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/1.12/windows/windowsservercore-ltsc2016/Dockerfile
@@ -46,13 +46,13 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
 
-ENV GOLANG_VERSION 1.12.7
+ENV GOLANG_VERSION 1.12.8
 
 RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSION); \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
-	$sha256 = '502712c0e29edc6b9cda6fa5e4b6ff9b36e27d225373baead8708c9634aa8e50'; \
+	$sha256 = '4352ed90240ddc1b6379adf3210b849b8e89a173ca00616f2beff53df9fef3c8'; \
 	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
 	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
 		Write-Host 'FAILED!'; \


### PR DESCRIPTION
New versions are up per https://golang.org/dl/ to address security vulnerabilities