### PR TITLE
Windows: improve consistency in install verify steps

### DIFF
--- a/1.12/windows/windowsservercore-1803/Dockerfile
+++ b/1.12/windows/windowsservercore-1803/Dockerfile
@@ -32,8 +32,8 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	$env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
 	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
 	\
-	Write-Host 'Verifying install ...'; \
-	Write-Host '  git --version'; git --version; \
+	Write-Host 'Verifying install ("git version") ...'; \
+	git version; \
 	\
 	Write-Host 'Complete.';
 
@@ -62,11 +62,11 @@ RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSI
 	Write-Host 'Expanding ...'; \
 	Expand-Archive go.zip -DestinationPath C:\; \
 	\
-	Write-Host 'Verifying install ("go version") ...'; \
-	go version; \
-	\
 	Write-Host 'Removing ...'; \
 	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
 	\
 	Write-Host 'Complete.';
 

--- a/1.12/windows/windowsservercore-1809/Dockerfile
+++ b/1.12/windows/windowsservercore-1809/Dockerfile
@@ -32,8 +32,8 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	$env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
 	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
 	\
-	Write-Host 'Verifying install ...'; \
-	Write-Host '  git --version'; git --version; \
+	Write-Host 'Verifying install ("git version") ...'; \
+	git version; \
 	\
 	Write-Host 'Complete.';
 
@@ -62,11 +62,11 @@ RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSI
 	Write-Host 'Expanding ...'; \
 	Expand-Archive go.zip -DestinationPath C:\; \
 	\
-	Write-Host 'Verifying install ("go version") ...'; \
-	go version; \
-	\
 	Write-Host 'Removing ...'; \
 	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
 	\
 	Write-Host 'Complete.';
 

--- a/1.12/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/1.12/windows/windowsservercore-ltsc2016/Dockerfile
@@ -32,8 +32,8 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	$env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
 	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
 	\
-	Write-Host 'Verifying install ...'; \
-	Write-Host '  git --version'; git --version; \
+	Write-Host 'Verifying install ("git version") ...'; \
+	git version; \
 	\
 	Write-Host 'Complete.';
 
@@ -62,11 +62,11 @@ RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSI
 	Write-Host 'Expanding ...'; \
 	Expand-Archive go.zip -DestinationPath C:\; \
 	\
-	Write-Host 'Verifying install ("go version") ...'; \
-	go version; \
-	\
 	Write-Host 'Removing ...'; \
 	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
 	\
 	Write-Host 'Complete.';
 

--- a/1.13/windows/windowsservercore-1803/Dockerfile
+++ b/1.13/windows/windowsservercore-1803/Dockerfile
@@ -32,8 +32,8 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	$env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
 	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
 	\
-	Write-Host 'Verifying install ...'; \
-	Write-Host '  git --version'; git --version; \
+	Write-Host 'Verifying install ("git version") ...'; \
+	git version; \
 	\
 	Write-Host 'Complete.';
 
@@ -62,11 +62,11 @@ RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSI
 	Write-Host 'Expanding ...'; \
 	Expand-Archive go.zip -DestinationPath C:\; \
 	\
-	Write-Host 'Verifying install ("go version") ...'; \
-	go version; \
-	\
 	Write-Host 'Removing ...'; \
 	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
 	\
 	Write-Host 'Complete.';
 

--- a/1.13/windows/windowsservercore-1809/Dockerfile
+++ b/1.13/windows/windowsservercore-1809/Dockerfile
@@ -32,8 +32,8 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	$env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
 	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
 	\
-	Write-Host 'Verifying install ...'; \
-	Write-Host '  git --version'; git --version; \
+	Write-Host 'Verifying install ("git version") ...'; \
+	git version; \
 	\
 	Write-Host 'Complete.';
 
@@ -62,11 +62,11 @@ RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSI
 	Write-Host 'Expanding ...'; \
 	Expand-Archive go.zip -DestinationPath C:\; \
 	\
-	Write-Host 'Verifying install ("go version") ...'; \
-	go version; \
-	\
 	Write-Host 'Removing ...'; \
 	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
 	\
 	Write-Host 'Complete.';
 

--- a/1.13/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/1.13/windows/windowsservercore-ltsc2016/Dockerfile
@@ -32,8 +32,8 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	$env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
 	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
 	\
-	Write-Host 'Verifying install ...'; \
-	Write-Host '  git --version'; git --version; \
+	Write-Host 'Verifying install ("git version") ...'; \
+	git version; \
 	\
 	Write-Host 'Complete.';
 
@@ -62,11 +62,11 @@ RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSI
 	Write-Host 'Expanding ...'; \
 	Expand-Archive go.zip -DestinationPath C:\; \
 	\
-	Write-Host 'Verifying install ("go version") ...'; \
-	go version; \
-	\
 	Write-Host 'Removing ...'; \
 	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
 	\
 	Write-Host 'Complete.';
 

--- a/Dockerfile-windows-windowsservercore.template
+++ b/Dockerfile-windows-windowsservercore.template
@@ -32,8 +32,8 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	$env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
 	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
 	\
-	Write-Host 'Verifying install ...'; \
-	Write-Host '  git --version'; git --version; \
+	Write-Host 'Verifying install ("git version") ...'; \
+	git version; \
 	\
 	Write-Host 'Complete.';
 
@@ -62,11 +62,11 @@ RUN $url = ('https://golang.org/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSI
 	Write-Host 'Expanding ...'; \
 	Expand-Archive go.zip -DestinationPath C:\; \
 	\
-	Write-Host 'Verifying install ("go version") ...'; \
-	go version; \
-	\
 	Write-Host 'Removing ...'; \
 	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
 	\
 	Write-Host 'Complete.';
 


### PR DESCRIPTION
Very insignificant change, but it looked a bit cleaner 🙈 🤗  🚲 🏠

Before this change:

    Expanding ...
    Removing ...
    Updating PATH ...
    Verifying install ...
     git --version
    git version 2.11.1.windows.1
    Complete.

    ....

    Expanding ...
    Verifying install (go version) ...
    go version go1.13 windows/amd64
    Removing ...
    Complete.

After this change:

    Expanding ...
    Removing ...
    Updating PATH ...
    Verifying install (git version) ...
    git version 2.11.1.windows.1
    Complete.

    ....

    Expanding ...
    Removing ...
    Verifying install (go version) ...
    go version go1.13 windows/amd64
    Complete.
