### PR TITLE
Add alpine:3.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,13 @@ matrix:
     - os: linux
       env: VERSION=1.14-rc VARIANT=buster
     - os: linux
-      env: VERSION=1.14-rc VARIANT=alpine3.10
+      env: VERSION=1.14-rc VARIANT=alpine3.11
     - os: linux
       env: VERSION=1.13 VARIANT=buster
     - os: linux
       env: VERSION=1.13 VARIANT=stretch
+    - os: linux
+      env: VERSION=1.13 VARIANT=alpine3.11
     - os: linux
       env: VERSION=1.13 VARIANT=alpine3.10
     - os: linux
@@ -18,9 +20,9 @@ matrix:
     - os: linux
       env: VERSION=1.12 VARIANT=stretch
     - os: linux
-      env: VERSION=1.12 VARIANT=alpine3.10
+      env: VERSION=1.12 VARIANT=alpine3.11
     - os: linux
-      env: VERSION=1.12 VARIANT=alpine3.9
+      env: VERSION=1.12 VARIANT=alpine3.10
 
 install:
   - git clone https://github.com/docker-library/official-images.git ~/official-images

--- a/1.12/alpine3.11/Dockerfile
+++ b/1.12/alpine3.11/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.11
 
 RUN apk add --no-cache \
 		ca-certificates

--- a/1.13/alpine3.11/Dockerfile
+++ b/1.13/alpine3.11/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.11
 
 RUN apk add --no-cache \
 		ca-certificates
@@ -8,7 +8,7 @@ RUN apk add --no-cache \
 # - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
 RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 
-ENV GOLANG_VERSION 1.14beta1
+ENV GOLANG_VERSION 1.13.5
 
 RUN set -eux; \
 	apk add --no-cache --virtual .build-deps \
@@ -37,7 +37,7 @@ RUN set -eux; \
 	esac; \
 	\
 	wget -O go.tgz "https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz"; \
-	echo 'af952217fcb408180006f29e77f1c3b871192fba7f99abd5aa421cf2f0358fea *go.tgz' | sha256sum -c -; \
+	echo '27d356e2a0b30d9983b60a788cf225da5f914066b37a6b4f69d457ba55a626ff *go.tgz' | sha256sum -c -; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
 	\

--- a/1.14-rc/alpine3.11/Dockerfile
+++ b/1.14-rc/alpine3.11/Dockerfile
@@ -1,0 +1,63 @@
+FROM alpine:3.11
+
+RUN apk add --no-cache \
+		ca-certificates
+
+# set up nsswitch.conf for Go's "netgo" implementation
+# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+# - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
+ENV GOLANG_VERSION 1.14beta1
+
+RUN set -eux; \
+	apk add --no-cache --virtual .build-deps \
+		bash \
+		gcc \
+		musl-dev \
+		openssl \
+		go \
+	; \
+	export \
+# set GOROOT_BOOTSTRAP such that we can actually build Go
+		GOROOT_BOOTSTRAP="$(go env GOROOT)" \
+# ... and set "cross-building" related vars to the installed system's values so that we create a build targeting the proper arch
+# (for example, if our build host is GOARCH=amd64, but our build env/image is GOARCH=386, our build needs GOARCH=386)
+		GOOS="$(go env GOOS)" \
+		GOARCH="$(go env GOARCH)" \
+		GOHOSTOS="$(go env GOHOSTOS)" \
+		GOHOSTARCH="$(go env GOHOSTARCH)" \
+	; \
+# also explicitly set GO386 and GOARM if appropriate
+# https://github.com/docker-library/golang/issues/184
+	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+		armhf) export GOARM='6' ;; \
+		x86) export GO386='387' ;; \
+	esac; \
+	\
+	wget -O go.tgz "https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz"; \
+	echo 'af952217fcb408180006f29e77f1c3b871192fba7f99abd5aa421cf2f0358fea *go.tgz' | sha256sum -c -; \
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+	cd /usr/local/go/src; \
+	./make.bash; \
+	\
+	rm -rf \
+# https://github.com/golang/go/blob/0b30cf534a03618162d3015c8705dd2231e34703/src/cmd/dist/buildtool.go#L121-L125
+		/usr/local/go/pkg/bootstrap \
+# https://golang.org/cl/82095
+# https://github.com/golang/build/blob/e3fe1605c30f6a3fd136b561569933312ede8782/cmd/release/releaselet.go#L56
+		/usr/local/go/pkg/obj \
+	; \
+	apk del .build-deps; \
+	\
+	export PATH="/usr/local/go/bin:$PATH"; \
+	go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -10,7 +10,7 @@ defaultDebianSuite='buster'
 declare -A debianSuite=(
 	#[1.13-rc]='buster'
 )
-defaultAlpineVersion='3.10'
+defaultAlpineVersion='3.11'
 declare -A alpineVersion=(
 	#[1.9]='3.7'
 )
@@ -77,7 +77,7 @@ for version in "${versions[@]}"; do
 	)
 
 	for v in \
-		buster stretch alpine{3.10,3.9} \
+		buster stretch alpine{3.11,3.10} \
 		windows/windowsservercore-{ltsc2016,1809} \
 		windows/nanoserver-1809 \
 	; do

--- a/update.sh
+++ b/update.sh
@@ -84,7 +84,7 @@ for version in "${versions[@]}"; do
 	windowsSha256="$(curl -fsSL "https://storage.googleapis.com/golang/go${fullVersion}.windows-amd64.zip.sha256")"
 
 	for variant in \
-		alpine{3.9,3.10} \
+		alpine{3.10,3.11} \
 		stretch buster \
 	; do
 		if [ -d "$version/$variant" ]; then


### PR DESCRIPTION
It should:

- add golang:1.12-alpine3.11
- add golang:1.13-alpine3.11
- add golang:1.14-rc-alpine3.11
- remove golang:1.12-alpine3.9
- remove golang:1.14-rc-alpine3.10
- set alpine 3.11 as default for alpine base.

Release note: https://alpinelinux.org/posts/Alpine-3.11.0-released.html