### PR TITLE
Add "gpgconf --kill all" to GnuPG invocations

### DIFF
--- a/1.14/alpine3.11/Dockerfile
+++ b/1.14/alpine3.11/Dockerfile
@@ -59,6 +59,7 @@ RUN set -eux; \
 # https://www.google.com/linuxrepositories/
 	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC EC91 7721 F63B D38B 4796'; \
 	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" go.tgz.asc; \
 	\
 	tar -C /usr/local -xzf go.tgz; \

--- a/1.14/alpine3.12/Dockerfile
+++ b/1.14/alpine3.12/Dockerfile
@@ -59,6 +59,7 @@ RUN set -eux; \
 # https://www.google.com/linuxrepositories/
 	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC EC91 7721 F63B D38B 4796'; \
 	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" go.tgz.asc; \
 	\
 	tar -C /usr/local -xzf go.tgz; \

--- a/1.14/buster/Dockerfile
+++ b/1.14/buster/Dockerfile
@@ -73,6 +73,7 @@ RUN set -eux; \
 # https://www.google.com/linuxrepositories/
 	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC EC91 7721 F63B D38B 4796'; \
 	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" go.tgz.asc; \
 	\
 	tar -C /usr/local -xzf go.tgz; \

--- a/1.14/stretch/Dockerfile
+++ b/1.14/stretch/Dockerfile
@@ -73,6 +73,7 @@ RUN set -eux; \
 # https://www.google.com/linuxrepositories/
 	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC EC91 7721 F63B D38B 4796'; \
 	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" go.tgz.asc; \
 	\
 	tar -C /usr/local -xzf go.tgz; \

--- a/1.15/alpine3.12/Dockerfile
+++ b/1.15/alpine3.12/Dockerfile
@@ -59,6 +59,7 @@ RUN set -eux; \
 # https://www.google.com/linuxrepositories/
 	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC EC91 7721 F63B D38B 4796'; \
 	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" go.tgz.asc; \
 	\
 	tar -C /usr/local -xzf go.tgz; \

--- a/1.15/buster/Dockerfile
+++ b/1.15/buster/Dockerfile
@@ -73,6 +73,7 @@ RUN set -eux; \
 # https://www.google.com/linuxrepositories/
 	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC EC91 7721 F63B D38B 4796'; \
 	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" go.tgz.asc; \
 	\
 	tar -C /usr/local -xzf go.tgz; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -53,6 +53,7 @@ RUN set -eux; \
 # https://www.google.com/linuxrepositories/
 	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC EC91 7721 F63B D38B 4796'; \
 	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" go.tgz.asc; \
 	\
 	tar -C /usr/local -xzf go.tgz; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -64,6 +64,7 @@ RUN set -eux; \
 # https://www.google.com/linuxrepositories/
 	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC EC91 7721 F63B D38B 4796'; \
 	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" go.tgz.asc; \
 	\
 	tar -C /usr/local -xzf go.tgz; \


### PR DESCRIPTION
Forgot this bit when I added GPG in https://github.com/docker-library/golang/pull/339 :sweat_smile: