### PR TITLE
Adds Git

### DIFF
--- a/1.14/alpine3.11/Dockerfile
+++ b/1.14/alpine3.11/Dockerfile
@@ -24,6 +24,7 @@ RUN set -eux; \
 		gcc \
 		gnupg \
 		go \
+		git \
 		musl-dev \
 		openssl \
 	; \

--- a/1.14/alpine3.12/Dockerfile
+++ b/1.14/alpine3.12/Dockerfile
@@ -24,6 +24,7 @@ RUN set -eux; \
 		gcc \
 		gnupg \
 		go \
+		git \
 		musl-dev \
 		openssl \
 	; \

--- a/1.15/alpine3.12/Dockerfile
+++ b/1.15/alpine3.12/Dockerfile
@@ -24,6 +24,7 @@ RUN set -eux; \
 		gcc \
 		gnupg \
 		go \
+		git \
 		musl-dev \
 		openssl \
 	; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -18,7 +18,7 @@ RUN set -eux; \
 		gcc \
 		gnupg \
 		go \
-                git \
+		git \
 		musl-dev \
 		openssl \
 	; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -18,6 +18,7 @@ RUN set -eux; \
 		gcc \
 		gnupg \
 		go \
+                git \
 		musl-dev \
 		openssl \
 	; \


### PR DESCRIPTION
It appears the upstream alpine image stopped baking git in their image which is essential for `go get`. This PR simply re-adds functionality that was lost from upstream alpine.