### PR TITLE
Ensure git is installed in alpine image

### DIFF
--- a/1.14/alpine3.11/Dockerfile
+++ b/1.14/alpine3.11/Dockerfile
@@ -26,6 +26,7 @@ RUN set -eux; \
 		go \
 		musl-dev \
 		openssl \
+		git \
 	; \
 	export \
 # set GOROOT_BOOTSTRAP such that we can actually build Go

--- a/1.14/alpine3.12/Dockerfile
+++ b/1.14/alpine3.12/Dockerfile
@@ -26,6 +26,7 @@ RUN set -eux; \
 		go \
 		musl-dev \
 		openssl \
+		git \
 	; \
 	export \
 # set GOROOT_BOOTSTRAP such that we can actually build Go

--- a/1.15/alpine3.12/Dockerfile
+++ b/1.15/alpine3.12/Dockerfile
@@ -26,6 +26,7 @@ RUN set -eux; \
 		go \
 		musl-dev \
 		openssl \
+		git \
 	; \
 	export \
 # set GOROOT_BOOTSTRAP such that we can actually build Go

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -20,6 +20,7 @@ RUN set -eux; \
 		go \
 		musl-dev \
 		openssl \
+		git \
 	; \
 	export \
 # set GOROOT_BOOTSTRAP such that we can actually build Go


### PR DESCRIPTION
Apparently, a recent update to the upstream alpine image has resulted in git no longer being installed by default in the alpine container image.  This pull request ensures that git is installed.

Closes issue #346