### PR TITLE
Update GO386 to "softfloat" in 1.16+

### DIFF
--- a/1.16-rc/alpine3.12/Dockerfile
+++ b/1.16-rc/alpine3.12/Dockerfile
@@ -43,7 +43,7 @@ RUN set -eux; \
 	case "$apkArch" in \
 		armhf) export GOARM='6' ;; \
 		armv7) export GOARM='7' ;; \
-		x86) export GO386='387' ;; \
+		x86) export GO386='softfloat' ;; \
 	esac; \
 	\
 # https://github.com/golang/go/issues/38536#issuecomment-616897960

--- a/1.16-rc/alpine3.13/Dockerfile
+++ b/1.16-rc/alpine3.13/Dockerfile
@@ -43,7 +43,7 @@ RUN set -eux; \
 	case "$apkArch" in \
 		armhf) export GOARM='6' ;; \
 		armv7) export GOARM='7' ;; \
-		x86) export GO386='387' ;; \
+		x86) export GO386='softfloat' ;; \
 	esac; \
 	\
 # https://github.com/golang/go/issues/38536#issuecomment-616897960

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -37,7 +37,7 @@ RUN set -eux; \
 	case "$apkArch" in \
 		armhf) export GOARM='6' ;; \
 		armv7) export GOARM='7' ;; \
-		x86) export GO386='387' ;; \
+		x86) export GO386='{{ if env.version == "1.14" or env.version == "1.15" then "387" else "softfloat" end }}' ;; \
 	esac; \
 	\
 # https://github.com/golang/go/issues/38536#issuecomment-616897960


### PR DESCRIPTION
See https://tip.golang.org/doc/go1.16#386.

It appears Alpine's definition of "x86" roughly matches Debian's definition of "i386" (ie, no sse2): https://gitlab.alpinelinux.org/alpine/aports/-/blob/39606c42c09836d93d2dac5469713b5f1d637682/community/go/APKBUILD#L74

Debian references (for posterity):

- https://www.debian.org/releases/stable/i386/ch02s01.en.html#idm276
- https://packages.debian.org/sid/sse2-support
- https://wiki.debian.org/ArchitectureSpecificsMemo#Architecture_baselines

(The Go 1.16 + `i386` + Alpine combination has been failing to build since it was introduced :sweat_smile:)