### PR TITLE
Fix i386 "softfloat" bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/docker-library/bashbrew.git -b master ~/bashbrew
           strategy="$(~/bashbrew/scripts/github-actions/generate.sh)"
+          strategy="$(~/bashbrew/scripts/github-actions/munge-i386.sh -c <<<"$strategy")"
           jq . <<<"$strategy" # sanity check / debugging aid
           echo "::set-output name=strategy::$strategy"
 

--- a/1.15/alpine3.12/Dockerfile
+++ b/1.15/alpine3.12/Dockerfile
@@ -27,23 +27,30 @@ RUN set -eux; \
 		musl-dev \
 		openssl \
 	; \
-	export \
-# set GOROOT_BOOTSTRAP such that we can actually build Go
-		GOROOT_BOOTSTRAP="$(go env GOROOT)" \
-# ... and set "cross-building" related vars to the installed system's values so that we create a build targeting the proper arch
-# (for example, if our build host is GOARCH=amd64, but our build env/image is GOARCH=386, our build needs GOARCH=386)
-		GOOS="$(go env GOOS)" \
-		GOARCH="$(go env GOARCH)" \
-		GOHOSTOS="$(go env GOHOSTOS)" \
-		GOHOSTARCH="$(go env GOHOSTARCH)" \
-	; \
-# also explicitly set GO386 and GOARM if appropriate
-# https://github.com/docker-library/golang/issues/184
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
-		armhf) export GOARM='6' ;; \
-		armv7) export GOARM='7' ;; \
-		x86) export GO386='387' ;; \
+		'x86_64') \
+			export GOARCH='amd64' GOOS='linux'; \
+			;; \
+		'armhf') \
+			export GOARCH='arm' GOARM='6' GOOS='linux'; \
+			;; \
+		'armv7') \
+			export GOARCH='arm' GOARM='7' GOOS='linux'; \
+			;; \
+		'aarch64') \
+			export GOARCH='arm64' GOOS='linux'; \
+			;; \
+		'x86') \
+			export GO386='387' GOARCH='386' GOOS='linux'; \
+			;; \
+		'ppc64le') \
+			export GOARCH='ppc64le' GOOS='linux'; \
+			;; \
+		's390x') \
+			export GOARCH='s390x' GOOS='linux'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$apkArch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
 	\
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
@@ -65,13 +72,21 @@ RUN set -eux; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
 	\
-	goEnv="$(go env | sed -rn -e '/^GO(OS|ARCH|ARM|386)=/s//export \0/p')"; \
-	eval "$goEnv"; \
-	[ -n "$GOOS" ]; \
-	[ -n "$GOARCH" ]; \
 	( \
 		cd /usr/local/go/src; \
+# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
+		export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
+		if [ "${GO386:-}" = 'softfloat' ]; then \
+# https://github.com/docker-library/golang/issues/359 -> https://github.com/golang/go/issues/44500
+# (once our Alpine base has Go 1.16, we can remove this hack)
+			GO386= ./bootstrap.bash; \
+			export GOROOT_BOOTSTRAP="/usr/local/go-$GOOS-$GOARCH-bootstrap"; \
+			"$GOROOT_BOOTSTRAP/bin/go" version; \
+		fi; \
 		./make.bash; \
+		if [ "${GO386:-}" = 'softfloat' ]; then \
+			rm -rf "$GOROOT_BOOTSTRAP"; \
+		fi; \
 	); \
 	\
 	apk del --no-network .build-deps; \

--- a/1.15/alpine3.13/Dockerfile
+++ b/1.15/alpine3.13/Dockerfile
@@ -27,23 +27,30 @@ RUN set -eux; \
 		musl-dev \
 		openssl \
 	; \
-	export \
-# set GOROOT_BOOTSTRAP such that we can actually build Go
-		GOROOT_BOOTSTRAP="$(go env GOROOT)" \
-# ... and set "cross-building" related vars to the installed system's values so that we create a build targeting the proper arch
-# (for example, if our build host is GOARCH=amd64, but our build env/image is GOARCH=386, our build needs GOARCH=386)
-		GOOS="$(go env GOOS)" \
-		GOARCH="$(go env GOARCH)" \
-		GOHOSTOS="$(go env GOHOSTOS)" \
-		GOHOSTARCH="$(go env GOHOSTARCH)" \
-	; \
-# also explicitly set GO386 and GOARM if appropriate
-# https://github.com/docker-library/golang/issues/184
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
-		armhf) export GOARM='6' ;; \
-		armv7) export GOARM='7' ;; \
-		x86) export GO386='387' ;; \
+		'x86_64') \
+			export GOARCH='amd64' GOOS='linux'; \
+			;; \
+		'armhf') \
+			export GOARCH='arm' GOARM='6' GOOS='linux'; \
+			;; \
+		'armv7') \
+			export GOARCH='arm' GOARM='7' GOOS='linux'; \
+			;; \
+		'aarch64') \
+			export GOARCH='arm64' GOOS='linux'; \
+			;; \
+		'x86') \
+			export GO386='387' GOARCH='386' GOOS='linux'; \
+			;; \
+		'ppc64le') \
+			export GOARCH='ppc64le' GOOS='linux'; \
+			;; \
+		's390x') \
+			export GOARCH='s390x' GOOS='linux'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$apkArch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
 	\
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
@@ -65,13 +72,21 @@ RUN set -eux; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
 	\
-	goEnv="$(go env | sed -rn -e '/^GO(OS|ARCH|ARM|386)=/s//export \0/p')"; \
-	eval "$goEnv"; \
-	[ -n "$GOOS" ]; \
-	[ -n "$GOARCH" ]; \
 	( \
 		cd /usr/local/go/src; \
+# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
+		export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
+		if [ "${GO386:-}" = 'softfloat' ]; then \
+# https://github.com/docker-library/golang/issues/359 -> https://github.com/golang/go/issues/44500
+# (once our Alpine base has Go 1.16, we can remove this hack)
+			GO386= ./bootstrap.bash; \
+			export GOROOT_BOOTSTRAP="/usr/local/go-$GOOS-$GOARCH-bootstrap"; \
+			"$GOROOT_BOOTSTRAP/bin/go" version; \
+		fi; \
 		./make.bash; \
+		if [ "${GO386:-}" = 'softfloat' ]; then \
+			rm -rf "$GOROOT_BOOTSTRAP"; \
+		fi; \
 	); \
 	\
 	apk del --no-network .build-deps; \

--- a/1.15/buster/Dockerfile
+++ b/1.15/buster/Dockerfile
@@ -22,47 +22,50 @@ ENV GOLANG_VERSION 1.15.8
 RUN set -eux; \
 	\
 	dpkgArch="$(dpkg --print-architecture)"; \
+	url=; \
 	case "${dpkgArch##*-}" in \
 		'amd64') \
-			arch='linux-amd64'; \
 			url='https://storage.googleapis.com/golang/go1.15.8.linux-amd64.tar.gz'; \
 			sha256='d3379c32a90fdf9382166f8f48034c459a8cc433730bc9476d39d9082c94583b'; \
 			;; \
+		'armel') \
+			export GOARCH='arm' GOARM='5' GOOS='linux'; \
+			;; \
 		'armhf') \
-			arch='linux-armv6l'; \
 			url='https://storage.googleapis.com/golang/go1.15.8.linux-armv6l.tar.gz'; \
 			sha256='708c398cb9e5029cfd5b654370978bf0e797d4d4a71153c06c7378db7e249a53'; \
 			;; \
 		'arm64') \
-			arch='linux-arm64'; \
 			url='https://storage.googleapis.com/golang/go1.15.8.linux-arm64.tar.gz'; \
 			sha256='0e31ea4bf53496b0f0809730520dee98c0ae5c530f3701a19df0ba0a327bf3d2'; \
 			;; \
 		'i386') \
-			arch='linux-386'; \
 			url='https://storage.googleapis.com/golang/go1.15.8.linux-386.tar.gz'; \
 			sha256='a0cc9df6d04f89af8396278d171087894a453a03a950b0f60a4ac18b480f758f'; \
 			;; \
+		'mips64el') \
+			export GOARCH='mips64le' GOOS='linux'; \
+			;; \
 		'ppc64el') \
-			arch='linux-ppc64le'; \
 			url='https://storage.googleapis.com/golang/go1.15.8.linux-ppc64le.tar.gz'; \
 			sha256='c6ddeab22b23ee33f5e8f06f9667e2092f48dbc6d5db553a66f7fe21da73fbfa'; \
 			;; \
 		's390x') \
-			arch='linux-s390x'; \
 			url='https://storage.googleapis.com/golang/go1.15.8.linux-s390x.tar.gz'; \
 			sha256='ba922f54fe99dee3246705bacbfac27fa88375439025429297aa1e9caf3f2297'; \
 			;; \
-		*) \
-# https://github.com/golang/go/issues/38536#issuecomment-616897960
-			arch='src'; \
-			url='https://storage.googleapis.com/golang/go1.15.8.src.tar.gz'; \
-			sha256='540c0ab7781084d124991321ed1458e479982de94454a98afab6acadf38497c2'; \
-			echo >&2; \
-			echo >&2 "warning: current architecture ($dpkgArch) does not have a corresponding Go binary release; will be building from source"; \
-			echo >&2; \
-			;; \
+		*) echo >&2 "error: unsupported architecture '$dpkgArch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
+	build=; \
+	if [ -z "$url" ]; then \
+# https://github.com/golang/go/issues/38536#issuecomment-616897960
+		build=1; \
+		url='https://storage.googleapis.com/golang/go1.15.8.src.tar.gz'; \
+		sha256='540c0ab7781084d124991321ed1458e479982de94454a98afab6acadf38497c2'; \
+		echo >&2; \
+		echo >&2 "warning: current architecture ($dpkgArch) does not have a corresponding Go binary release; will be building from source"; \
+		echo >&2; \
+	fi; \
 	\
 	wget -O go.tgz.asc "$url.asc" --progress=dot:giga; \
 	wget -O go.tgz "$url" --progress=dot:giga; \
@@ -79,17 +82,15 @@ RUN set -eux; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
 	\
-	if [ "$arch" = 'src' ]; then \
+	if [ -n "$build" ]; then \
 		savedAptMark="$(apt-mark showmanual)"; \
 		apt-get update; \
 		apt-get install -y --no-install-recommends golang-go; \
 		\
-		goEnv="$(go env | sed -rn -e '/^GO(OS|ARCH|ARM|386)=/s//export \0/p')"; \
-		eval "$goEnv"; \
-		[ -n "$GOOS" ]; \
-		[ -n "$GOARCH" ]; \
 		( \
 			cd /usr/local/go/src; \
+# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
+			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
 			./make.bash; \
 		); \
 		\

--- a/1.16/alpine3.12/Dockerfile
+++ b/1.16/alpine3.12/Dockerfile
@@ -27,23 +27,30 @@ RUN set -eux; \
 		musl-dev \
 		openssl \
 	; \
-	export \
-# set GOROOT_BOOTSTRAP such that we can actually build Go
-		GOROOT_BOOTSTRAP="$(go env GOROOT)" \
-# ... and set "cross-building" related vars to the installed system's values so that we create a build targeting the proper arch
-# (for example, if our build host is GOARCH=amd64, but our build env/image is GOARCH=386, our build needs GOARCH=386)
-		GOOS="$(go env GOOS)" \
-		GOARCH="$(go env GOARCH)" \
-		GOHOSTOS="$(go env GOHOSTOS)" \
-		GOHOSTARCH="$(go env GOHOSTARCH)" \
-	; \
-# also explicitly set GO386 and GOARM if appropriate
-# https://github.com/docker-library/golang/issues/184
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
-		armhf) export GOARM='6' ;; \
-		armv7) export GOARM='7' ;; \
-		x86) export GO386='softfloat' ;; \
+		'x86_64') \
+			export GOARCH='amd64' GOOS='linux'; \
+			;; \
+		'armhf') \
+			export GOARCH='arm' GOARM='6' GOOS='linux'; \
+			;; \
+		'armv7') \
+			export GOARCH='arm' GOARM='7' GOOS='linux'; \
+			;; \
+		'aarch64') \
+			export GOARCH='arm64' GOOS='linux'; \
+			;; \
+		'x86') \
+			export GO386='softfloat' GOARCH='386' GOOS='linux'; \
+			;; \
+		'ppc64le') \
+			export GOARCH='ppc64le' GOOS='linux'; \
+			;; \
+		's390x') \
+			export GOARCH='s390x' GOOS='linux'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$apkArch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
 	\
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
@@ -65,13 +72,21 @@ RUN set -eux; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
 	\
-	goEnv="$(go env | sed -rn -e '/^GO(OS|ARCH|ARM|386)=/s//export \0/p')"; \
-	eval "$goEnv"; \
-	[ -n "$GOOS" ]; \
-	[ -n "$GOARCH" ]; \
 	( \
 		cd /usr/local/go/src; \
+# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
+		export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
+		if [ "${GO386:-}" = 'softfloat' ]; then \
+# https://github.com/docker-library/golang/issues/359 -> https://github.com/golang/go/issues/44500
+# (once our Alpine base has Go 1.16, we can remove this hack)
+			GO386= ./bootstrap.bash; \
+			export GOROOT_BOOTSTRAP="/usr/local/go-$GOOS-$GOARCH-bootstrap"; \
+			"$GOROOT_BOOTSTRAP/bin/go" version; \
+		fi; \
 		./make.bash; \
+		if [ "${GO386:-}" = 'softfloat' ]; then \
+			rm -rf "$GOROOT_BOOTSTRAP"; \
+		fi; \
 	); \
 	\
 	apk del --no-network .build-deps; \

--- a/1.16/alpine3.13/Dockerfile
+++ b/1.16/alpine3.13/Dockerfile
@@ -27,23 +27,30 @@ RUN set -eux; \
 		musl-dev \
 		openssl \
 	; \
-	export \
-# set GOROOT_BOOTSTRAP such that we can actually build Go
-		GOROOT_BOOTSTRAP="$(go env GOROOT)" \
-# ... and set "cross-building" related vars to the installed system's values so that we create a build targeting the proper arch
-# (for example, if our build host is GOARCH=amd64, but our build env/image is GOARCH=386, our build needs GOARCH=386)
-		GOOS="$(go env GOOS)" \
-		GOARCH="$(go env GOARCH)" \
-		GOHOSTOS="$(go env GOHOSTOS)" \
-		GOHOSTARCH="$(go env GOHOSTARCH)" \
-	; \
-# also explicitly set GO386 and GOARM if appropriate
-# https://github.com/docker-library/golang/issues/184
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
-		armhf) export GOARM='6' ;; \
-		armv7) export GOARM='7' ;; \
-		x86) export GO386='softfloat' ;; \
+		'x86_64') \
+			export GOARCH='amd64' GOOS='linux'; \
+			;; \
+		'armhf') \
+			export GOARCH='arm' GOARM='6' GOOS='linux'; \
+			;; \
+		'armv7') \
+			export GOARCH='arm' GOARM='7' GOOS='linux'; \
+			;; \
+		'aarch64') \
+			export GOARCH='arm64' GOOS='linux'; \
+			;; \
+		'x86') \
+			export GO386='softfloat' GOARCH='386' GOOS='linux'; \
+			;; \
+		'ppc64le') \
+			export GOARCH='ppc64le' GOOS='linux'; \
+			;; \
+		's390x') \
+			export GOARCH='s390x' GOOS='linux'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$apkArch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
 	\
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
@@ -65,13 +72,21 @@ RUN set -eux; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
 	\
-	goEnv="$(go env | sed -rn -e '/^GO(OS|ARCH|ARM|386)=/s//export \0/p')"; \
-	eval "$goEnv"; \
-	[ -n "$GOOS" ]; \
-	[ -n "$GOARCH" ]; \
 	( \
 		cd /usr/local/go/src; \
+# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
+		export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
+		if [ "${GO386:-}" = 'softfloat' ]; then \
+# https://github.com/docker-library/golang/issues/359 -> https://github.com/golang/go/issues/44500
+# (once our Alpine base has Go 1.16, we can remove this hack)
+			GO386= ./bootstrap.bash; \
+			export GOROOT_BOOTSTRAP="/usr/local/go-$GOOS-$GOARCH-bootstrap"; \
+			"$GOROOT_BOOTSTRAP/bin/go" version; \
+		fi; \
 		./make.bash; \
+		if [ "${GO386:-}" = 'softfloat' ]; then \
+			rm -rf "$GOROOT_BOOTSTRAP"; \
+		fi; \
 	); \
 	\
 	apk del --no-network .build-deps; \

--- a/1.16/buster/Dockerfile
+++ b/1.16/buster/Dockerfile
@@ -22,47 +22,50 @@ ENV GOLANG_VERSION 1.16
 RUN set -eux; \
 	\
 	dpkgArch="$(dpkg --print-architecture)"; \
+	url=; \
 	case "${dpkgArch##*-}" in \
 		'amd64') \
-			arch='linux-amd64'; \
 			url='https://storage.googleapis.com/golang/go1.16.linux-amd64.tar.gz'; \
 			sha256='013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2'; \
 			;; \
+		'armel') \
+			export GOARCH='arm' GOARM='5' GOOS='linux'; \
+			;; \
 		'armhf') \
-			arch='linux-armv6l'; \
 			url='https://storage.googleapis.com/golang/go1.16.linux-armv6l.tar.gz'; \
 			sha256='d1d9404b1dbd77afa2bdc70934e10fbfcf7d785c372efc29462bb7d83d0a32fd'; \
 			;; \
 		'arm64') \
-			arch='linux-arm64'; \
 			url='https://storage.googleapis.com/golang/go1.16.linux-arm64.tar.gz'; \
 			sha256='3770f7eb22d05e25fbee8fb53c2a4e897da043eb83c69b9a14f8d98562cd8098'; \
 			;; \
 		'i386') \
-			arch='linux-386'; \
 			url='https://storage.googleapis.com/golang/go1.16.linux-386.tar.gz'; \
 			sha256='ea435a1ac6d497b03e367fdfb74b33e961d813883468080f6e239b3b03bea6aa'; \
 			;; \
+		'mips64el') \
+			export GOARCH='mips64le' GOOS='linux'; \
+			;; \
 		'ppc64el') \
-			arch='linux-ppc64le'; \
 			url='https://storage.googleapis.com/golang/go1.16.linux-ppc64le.tar.gz'; \
 			sha256='27a1aaa988e930b7932ce459c8a63ad5b3333b3a06b016d87ff289f2a11aacd6'; \
 			;; \
 		's390x') \
-			arch='linux-s390x'; \
 			url='https://storage.googleapis.com/golang/go1.16.linux-s390x.tar.gz'; \
 			sha256='be4c9e4e2cf058efc4e3eb013a760cb989ddc4362f111950c990d1c63b27ccbe'; \
 			;; \
-		*) \
-# https://github.com/golang/go/issues/38536#issuecomment-616897960
-			arch='src'; \
-			url='https://storage.googleapis.com/golang/go1.16.src.tar.gz'; \
-			sha256='7688063d55656105898f323d90a79a39c378d86fe89ae192eb3b7fc46347c95a'; \
-			echo >&2; \
-			echo >&2 "warning: current architecture ($dpkgArch) does not have a corresponding Go binary release; will be building from source"; \
-			echo >&2; \
-			;; \
+		*) echo >&2 "error: unsupported architecture '$dpkgArch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
+	build=; \
+	if [ -z "$url" ]; then \
+# https://github.com/golang/go/issues/38536#issuecomment-616897960
+		build=1; \
+		url='https://storage.googleapis.com/golang/go1.16.src.tar.gz'; \
+		sha256='7688063d55656105898f323d90a79a39c378d86fe89ae192eb3b7fc46347c95a'; \
+		echo >&2; \
+		echo >&2 "warning: current architecture ($dpkgArch) does not have a corresponding Go binary release; will be building from source"; \
+		echo >&2; \
+	fi; \
 	\
 	wget -O go.tgz.asc "$url.asc" --progress=dot:giga; \
 	wget -O go.tgz "$url" --progress=dot:giga; \
@@ -79,17 +82,15 @@ RUN set -eux; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
 	\
-	if [ "$arch" = 'src' ]; then \
+	if [ -n "$build" ]; then \
 		savedAptMark="$(apt-mark showmanual)"; \
 		apt-get update; \
 		apt-get install -y --no-install-recommends golang-go; \
 		\
-		goEnv="$(go env | sed -rn -e '/^GO(OS|ARCH|ARM|386)=/s//export \0/p')"; \
-		eval "$goEnv"; \
-		[ -n "$GOOS" ]; \
-		[ -n "$GOARCH" ]; \
 		( \
 			cd /usr/local/go/src; \
+# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
+			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
 			./make.bash; \
 		); \
 		\

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -21,23 +21,35 @@ RUN set -eux; \
 		musl-dev \
 		openssl \
 	; \
-	export \
-# set GOROOT_BOOTSTRAP such that we can actually build Go
-		GOROOT_BOOTSTRAP="$(go env GOROOT)" \
-# ... and set "cross-building" related vars to the installed system's values so that we create a build targeting the proper arch
-# (for example, if our build host is GOARCH=amd64, but our build env/image is GOARCH=386, our build needs GOARCH=386)
-		GOOS="$(go env GOOS)" \
-		GOARCH="$(go env GOARCH)" \
-		GOHOSTOS="$(go env GOHOSTOS)" \
-		GOHOSTARCH="$(go env GOHOSTARCH)" \
-	; \
-# also explicitly set GO386 and GOARM if appropriate
-# https://github.com/docker-library/golang/issues/184
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
-		armhf) export GOARM='6' ;; \
-		armv7) export GOARM='7' ;; \
-		x86) export GO386='{{ if env.version == "1.14" or env.version == "1.15" then "387" else "softfloat" end }}' ;; \
+{{
+	[
+		.arches | to_entries[]
+		| .key as $bashbrewArch
+		| (
+			{
+				amd64: "x86_64",
+				arm32v6: "armhf",
+				arm32v7: "armv7",
+				arm64v8: "aarch64",
+				i386: "x86",
+				ppc64le: "ppc64le",
+				s390x: "s390x",
+			} | .[$bashbrewArch] // ""
+		) as $apkArch
+		| select($apkArch != "")
+		| .value
+		| (
+-}}
+		{{ $apkArch | @sh }}) \
+			export {{ .env | to_entries | map(.key + "=" + (.value | @sh)) | join(" ") }}; \
+			;; \
+{{
+		)
+	] | add
+-}}
+		*) echo >&2 "error: unsupported architecture '$apkArch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
 	\
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
@@ -59,13 +71,21 @@ RUN set -eux; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
 	\
-	goEnv="$(go env | sed -rn -e '/^GO(OS|ARCH|ARM|386)=/s//export \0/p')"; \
-	eval "$goEnv"; \
-	[ -n "$GOOS" ]; \
-	[ -n "$GOARCH" ]; \
 	( \
 		cd /usr/local/go/src; \
+# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
+		export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
+		if [ "${GO386:-}" = 'softfloat' ]; then \
+# https://github.com/docker-library/golang/issues/359 -> https://github.com/golang/go/issues/44500
+# (once our Alpine base has Go 1.16, we can remove this hack)
+			GO386= ./bootstrap.bash; \
+			export GOROOT_BOOTSTRAP="/usr/local/go-$GOOS-$GOARCH-bootstrap"; \
+			"$GOROOT_BOOTSTRAP/bin/go" version; \
+		fi; \
 		./make.bash; \
+		if [ "${GO386:-}" = 'softfloat' ]; then \
+			rm -rf "$GOROOT_BOOTSTRAP"; \
+		fi; \
 	); \
 	\
 	apk del --no-network .build-deps; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -16,44 +16,52 @@ ENV GOLANG_VERSION {{ .version }}
 RUN set -eux; \
 	\
 	dpkgArch="$(dpkg --print-architecture)"; \
+	url=; \
 	case "${dpkgArch##*-}" in \
 {{
 	[
 		.arches | to_entries[]
-		| select(.value.arch | startswith("linux-"))
 		| .key as $bashbrewArch
 		| (
 			{
+				amd64: "amd64",
 				arm32v5: "armel",
 				arm32v7: "armhf",
 				arm64v8: "arm64",
+				i386: "i386",
 				mips64le: "mips64el",
 				ppc64le: "ppc64el",
-			}
-			| .[$bashbrewArch] // $bashbrewArch
+				s390x: "s390x",
+			} | .[$bashbrewArch] // ""
 		) as $dpkgArch
+		| select($dpkgArch != "")
 		| .value
 		| (
 -}}
 		{{ $dpkgArch | @sh }}) \
-			arch={{ .arch | @sh }}; \
+{{ if .url then ( -}}
 			url={{ .url | @sh }}; \
 			sha256={{ .sha256 | @sh }}; \
+{{ ) else ( -}}
+			export {{ .env | to_entries | map(.key + "=" + (.value | @sh)) | join(" ") }}; \
+{{ ) end -}}
 			;; \
 {{
 		)
 	] | add
 -}}
-		*) \
-# https://github.com/golang/go/issues/38536#issuecomment-616897960
-			arch='src'; \
-			url={{ .arches.src.url | @sh }}; \
-			sha256={{ .arches.src.sha256 | @sh }}; \
-			echo >&2; \
-			echo >&2 "warning: current architecture ($dpkgArch) does not have a corresponding Go binary release; will be building from source"; \
-			echo >&2; \
-			;; \
+		*) echo >&2 "error: unsupported architecture '$dpkgArch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
+	build=; \
+	if [ -z "$url" ]; then \
+# https://github.com/golang/go/issues/38536#issuecomment-616897960
+		build=1; \
+		url={{ .arches.src.url | @sh }}; \
+		sha256={{ .arches.src.sha256 | @sh }}; \
+		echo >&2; \
+		echo >&2 "warning: current architecture ($dpkgArch) does not have a corresponding Go binary release; will be building from source"; \
+		echo >&2; \
+	fi; \
 	\
 	wget -O go.tgz.asc "$url.asc" --progress=dot:giga; \
 	wget -O go.tgz "$url" --progress=dot:giga; \
@@ -70,17 +78,15 @@ RUN set -eux; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
 	\
-	if [ "$arch" = 'src' ]; then \
+	if [ -n "$build" ]; then \
 		savedAptMark="$(apt-mark showmanual)"; \
 		apt-get update; \
 		apt-get install -y --no-install-recommends golang-go; \
 		\
-		goEnv="$(go env | sed -rn -e '/^GO(OS|ARCH|ARM|386)=/s//export \0/p')"; \
-		eval "$goEnv"; \
-		[ -n "$GOOS" ]; \
-		[ -n "$GOARCH" ]; \
 		( \
 			cd /usr/local/go/src; \
+# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
+			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
 			./make.bash; \
 		); \
 		\

--- a/versions.json
+++ b/versions.json
@@ -2,42 +2,84 @@
   "1.15": {
     "arches": {
       "amd64": {
-        "arch": "linux-amd64",
+        "env": {
+          "GOARCH": "amd64",
+          "GOOS": "linux"
+        },
         "sha256": "d3379c32a90fdf9382166f8f48034c459a8cc433730bc9476d39d9082c94583b",
         "url": "https://storage.googleapis.com/golang/go1.15.8.linux-amd64.tar.gz"
       },
+      "arm32v5": {
+        "env": {
+          "GOARCH": "arm",
+          "GOARM": "5",
+          "GOOS": "linux"
+        }
+      },
+      "arm32v6": {
+        "env": {
+          "GOARCH": "arm",
+          "GOARM": "6",
+          "GOOS": "linux"
+        }
+      },
       "arm32v7": {
-        "arch": "linux-armv6l",
+        "env": {
+          "GOARCH": "arm",
+          "GOARM": "7",
+          "GOOS": "linux"
+        },
         "sha256": "708c398cb9e5029cfd5b654370978bf0e797d4d4a71153c06c7378db7e249a53",
         "url": "https://storage.googleapis.com/golang/go1.15.8.linux-armv6l.tar.gz"
       },
       "arm64v8": {
-        "arch": "linux-arm64",
+        "env": {
+          "GOARCH": "arm64",
+          "GOOS": "linux"
+        },
         "sha256": "0e31ea4bf53496b0f0809730520dee98c0ae5c530f3701a19df0ba0a327bf3d2",
         "url": "https://storage.googleapis.com/golang/go1.15.8.linux-arm64.tar.gz"
       },
       "i386": {
-        "arch": "linux-386",
+        "env": {
+          "GO386": "387",
+          "GOARCH": "386",
+          "GOOS": "linux"
+        },
         "sha256": "a0cc9df6d04f89af8396278d171087894a453a03a950b0f60a4ac18b480f758f",
         "url": "https://storage.googleapis.com/golang/go1.15.8.linux-386.tar.gz"
       },
+      "mips64le": {
+        "env": {
+          "GOARCH": "mips64le",
+          "GOOS": "linux"
+        }
+      },
       "ppc64le": {
-        "arch": "linux-ppc64le",
+        "env": {
+          "GOARCH": "ppc64le",
+          "GOOS": "linux"
+        },
         "sha256": "c6ddeab22b23ee33f5e8f06f9667e2092f48dbc6d5db553a66f7fe21da73fbfa",
         "url": "https://storage.googleapis.com/golang/go1.15.8.linux-ppc64le.tar.gz"
       },
       "s390x": {
-        "arch": "linux-s390x",
+        "env": {
+          "GOARCH": "s390x",
+          "GOOS": "linux"
+        },
         "sha256": "ba922f54fe99dee3246705bacbfac27fa88375439025429297aa1e9caf3f2297",
         "url": "https://storage.googleapis.com/golang/go1.15.8.linux-s390x.tar.gz"
       },
       "src": {
-        "arch": "src",
         "sha256": "540c0ab7781084d124991321ed1458e479982de94454a98afab6acadf38497c2",
         "url": "https://storage.googleapis.com/golang/go1.15.8.src.tar.gz"
       },
       "windows-amd64": {
-        "arch": "windows-amd64",
+        "env": {
+          "GOARCH": "amd64",
+          "GOOS": "windows"
+        },
         "sha256": "ef05b7141d3c217fb076f0e27249e144296234df96ead8751c0b76784079df97",
         "url": "https://storage.googleapis.com/golang/go1.15.8.windows-amd64.zip"
       }
@@ -55,42 +97,84 @@
   "1.16": {
     "arches": {
       "amd64": {
-        "arch": "linux-amd64",
+        "env": {
+          "GOARCH": "amd64",
+          "GOOS": "linux"
+        },
         "sha256": "013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2",
         "url": "https://storage.googleapis.com/golang/go1.16.linux-amd64.tar.gz"
       },
+      "arm32v5": {
+        "env": {
+          "GOARCH": "arm",
+          "GOARM": "5",
+          "GOOS": "linux"
+        }
+      },
+      "arm32v6": {
+        "env": {
+          "GOARCH": "arm",
+          "GOARM": "6",
+          "GOOS": "linux"
+        }
+      },
       "arm32v7": {
-        "arch": "linux-armv6l",
+        "env": {
+          "GOARCH": "arm",
+          "GOARM": "7",
+          "GOOS": "linux"
+        },
         "sha256": "d1d9404b1dbd77afa2bdc70934e10fbfcf7d785c372efc29462bb7d83d0a32fd",
         "url": "https://storage.googleapis.com/golang/go1.16.linux-armv6l.tar.gz"
       },
       "arm64v8": {
-        "arch": "linux-arm64",
+        "env": {
+          "GOARCH": "arm64",
+          "GOOS": "linux"
+        },
         "sha256": "3770f7eb22d05e25fbee8fb53c2a4e897da043eb83c69b9a14f8d98562cd8098",
         "url": "https://storage.googleapis.com/golang/go1.16.linux-arm64.tar.gz"
       },
       "i386": {
-        "arch": "linux-386",
+        "env": {
+          "GO386": "softfloat",
+          "GOARCH": "386",
+          "GOOS": "linux"
+        },
         "sha256": "ea435a1ac6d497b03e367fdfb74b33e961d813883468080f6e239b3b03bea6aa",
         "url": "https://storage.googleapis.com/golang/go1.16.linux-386.tar.gz"
       },
+      "mips64le": {
+        "env": {
+          "GOARCH": "mips64le",
+          "GOOS": "linux"
+        }
+      },
       "ppc64le": {
-        "arch": "linux-ppc64le",
+        "env": {
+          "GOARCH": "ppc64le",
+          "GOOS": "linux"
+        },
         "sha256": "27a1aaa988e930b7932ce459c8a63ad5b3333b3a06b016d87ff289f2a11aacd6",
         "url": "https://storage.googleapis.com/golang/go1.16.linux-ppc64le.tar.gz"
       },
       "s390x": {
-        "arch": "linux-s390x",
+        "env": {
+          "GOARCH": "s390x",
+          "GOOS": "linux"
+        },
         "sha256": "be4c9e4e2cf058efc4e3eb013a760cb989ddc4362f111950c990d1c63b27ccbe",
         "url": "https://storage.googleapis.com/golang/go1.16.linux-s390x.tar.gz"
       },
       "src": {
-        "arch": "src",
         "sha256": "7688063d55656105898f323d90a79a39c378d86fe89ae192eb3b7fc46347c95a",
         "url": "https://storage.googleapis.com/golang/go1.16.src.tar.gz"
       },
       "windows-amd64": {
-        "arch": "windows-amd64",
+        "env": {
+          "GOARCH": "amd64",
+          "GOOS": "windows"
+        },
         "sha256": "5cc88fa506b3d5c453c54c3ea218fc8dd05d7362ae1de15bb67986b72089ce93",
         "url": "https://storage.googleapis.com/golang/go1.16.windows-amd64.zip"
       }


### PR DESCRIPTION
See https://github.com/golang/go/issues/44500 for details (tldr, Go 1.16 changes "GO386" from "387" to "softfloat" but the bootstrap compiler isn't 1.16 yet so balks at the changed value).

This also makes our "compilation" much more explicit by explicitly noting the "env" needed to build each bashbrew architecture we support and embedding those directly.

(I've also added "i386" to GitHub Actions, which will double our matrix size, but will hopefully help us catch issues like this in the future.)

Fixes #359