### PR TITLE
Add "stretch" variants

### DIFF
--- a/1.15/stretch/Dockerfile
+++ b/1.15/stretch/Dockerfile
@@ -1,0 +1,123 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM buildpack-deps:stretch-scm
+
+# gcc for cgo
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		g++ \
+		gcc \
+		libc6-dev \
+		make \
+		pkg-config \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV PATH /usr/local/go/bin:$PATH
+
+ENV GOLANG_VERSION 1.15.8
+
+RUN set -eux; \
+	\
+	dpkgArch="$(dpkg --print-architecture)"; \
+	url=; \
+	case "${dpkgArch##*-}" in \
+		'amd64') \
+			url='https://storage.googleapis.com/golang/go1.15.8.linux-amd64.tar.gz'; \
+			sha256='d3379c32a90fdf9382166f8f48034c459a8cc433730bc9476d39d9082c94583b'; \
+			;; \
+		'armel') \
+			export GOARCH='arm' GOARM='5' GOOS='linux'; \
+			;; \
+		'armhf') \
+			url='https://storage.googleapis.com/golang/go1.15.8.linux-armv6l.tar.gz'; \
+			sha256='708c398cb9e5029cfd5b654370978bf0e797d4d4a71153c06c7378db7e249a53'; \
+			;; \
+		'arm64') \
+			url='https://storage.googleapis.com/golang/go1.15.8.linux-arm64.tar.gz'; \
+			sha256='0e31ea4bf53496b0f0809730520dee98c0ae5c530f3701a19df0ba0a327bf3d2'; \
+			;; \
+		'i386') \
+			url='https://storage.googleapis.com/golang/go1.15.8.linux-386.tar.gz'; \
+			sha256='a0cc9df6d04f89af8396278d171087894a453a03a950b0f60a4ac18b480f758f'; \
+			;; \
+		'mips64el') \
+			export GOARCH='mips64le' GOOS='linux'; \
+			;; \
+		'ppc64el') \
+			url='https://storage.googleapis.com/golang/go1.15.8.linux-ppc64le.tar.gz'; \
+			sha256='c6ddeab22b23ee33f5e8f06f9667e2092f48dbc6d5db553a66f7fe21da73fbfa'; \
+			;; \
+		's390x') \
+			url='https://storage.googleapis.com/golang/go1.15.8.linux-s390x.tar.gz'; \
+			sha256='ba922f54fe99dee3246705bacbfac27fa88375439025429297aa1e9caf3f2297'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$dpkgArch' (likely packaging update needed)"; exit 1 ;; \
+	esac; \
+	build=; \
+	if [ -z "$url" ]; then \
+# https://github.com/golang/go/issues/38536#issuecomment-616897960
+		build=1; \
+		url='https://storage.googleapis.com/golang/go1.15.8.src.tar.gz'; \
+		sha256='540c0ab7781084d124991321ed1458e479982de94454a98afab6acadf38497c2'; \
+		echo >&2; \
+		echo >&2 "warning: current architecture ($dpkgArch) does not have a corresponding Go binary release; will be building from source"; \
+		echo >&2; \
+	fi; \
+	\
+	wget -O go.tgz.asc "$url.asc" --progress=dot:giga; \
+	wget -O go.tgz "$url" --progress=dot:giga; \
+	echo "$sha256 *go.tgz" | sha256sum --strict --check -; \
+	\
+# https://github.com/golang/go/issues/14739#issuecomment-324767697
+	export GNUPGHOME="$(mktemp -d)"; \
+# https://www.google.com/linuxrepositories/
+	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC EC91 7721 F63B D38B 4796'; \
+	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" go.tgz.asc; \
+	\
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+	if [ -n "$build" ]; then \
+		savedAptMark="$(apt-mark showmanual)"; \
+		apt-get update; \
+		apt-get install -y --no-install-recommends golang-go; \
+		\
+		( \
+			cd /usr/local/go/src; \
+# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
+			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
+			./make.bash; \
+		); \
+		\
+		apt-mark auto '.*' > /dev/null; \
+		apt-mark manual $savedAptMark > /dev/null; \
+		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+		rm -rf /var/lib/apt/lists/*; \
+		\
+# pre-compile the standard library, just like the official binary release tarballs do
+		go install std; \
+# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
+#		go install -race std; \
+		\
+# remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
+		rm -rf \
+			/usr/local/go/pkg/*/cmd \
+			/usr/local/go/pkg/bootstrap \
+			/usr/local/go/pkg/obj \
+			/usr/local/go/pkg/tool/*/api \
+			/usr/local/go/pkg/tool/*/go_bootstrap \
+			/usr/local/go/src/cmd/dist/dist \
+		; \
+	fi; \
+	\
+	go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH

--- a/1.16/stretch/Dockerfile
+++ b/1.16/stretch/Dockerfile
@@ -1,0 +1,123 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM buildpack-deps:stretch-scm
+
+# gcc for cgo
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		g++ \
+		gcc \
+		libc6-dev \
+		make \
+		pkg-config \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV PATH /usr/local/go/bin:$PATH
+
+ENV GOLANG_VERSION 1.16
+
+RUN set -eux; \
+	\
+	dpkgArch="$(dpkg --print-architecture)"; \
+	url=; \
+	case "${dpkgArch##*-}" in \
+		'amd64') \
+			url='https://storage.googleapis.com/golang/go1.16.linux-amd64.tar.gz'; \
+			sha256='013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2'; \
+			;; \
+		'armel') \
+			export GOARCH='arm' GOARM='5' GOOS='linux'; \
+			;; \
+		'armhf') \
+			url='https://storage.googleapis.com/golang/go1.16.linux-armv6l.tar.gz'; \
+			sha256='d1d9404b1dbd77afa2bdc70934e10fbfcf7d785c372efc29462bb7d83d0a32fd'; \
+			;; \
+		'arm64') \
+			url='https://storage.googleapis.com/golang/go1.16.linux-arm64.tar.gz'; \
+			sha256='3770f7eb22d05e25fbee8fb53c2a4e897da043eb83c69b9a14f8d98562cd8098'; \
+			;; \
+		'i386') \
+			url='https://storage.googleapis.com/golang/go1.16.linux-386.tar.gz'; \
+			sha256='ea435a1ac6d497b03e367fdfb74b33e961d813883468080f6e239b3b03bea6aa'; \
+			;; \
+		'mips64el') \
+			export GOARCH='mips64le' GOOS='linux'; \
+			;; \
+		'ppc64el') \
+			url='https://storage.googleapis.com/golang/go1.16.linux-ppc64le.tar.gz'; \
+			sha256='27a1aaa988e930b7932ce459c8a63ad5b3333b3a06b016d87ff289f2a11aacd6'; \
+			;; \
+		's390x') \
+			url='https://storage.googleapis.com/golang/go1.16.linux-s390x.tar.gz'; \
+			sha256='be4c9e4e2cf058efc4e3eb013a760cb989ddc4362f111950c990d1c63b27ccbe'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$dpkgArch' (likely packaging update needed)"; exit 1 ;; \
+	esac; \
+	build=; \
+	if [ -z "$url" ]; then \
+# https://github.com/golang/go/issues/38536#issuecomment-616897960
+		build=1; \
+		url='https://storage.googleapis.com/golang/go1.16.src.tar.gz'; \
+		sha256='7688063d55656105898f323d90a79a39c378d86fe89ae192eb3b7fc46347c95a'; \
+		echo >&2; \
+		echo >&2 "warning: current architecture ($dpkgArch) does not have a corresponding Go binary release; will be building from source"; \
+		echo >&2; \
+	fi; \
+	\
+	wget -O go.tgz.asc "$url.asc" --progress=dot:giga; \
+	wget -O go.tgz "$url" --progress=dot:giga; \
+	echo "$sha256 *go.tgz" | sha256sum --strict --check -; \
+	\
+# https://github.com/golang/go/issues/14739#issuecomment-324767697
+	export GNUPGHOME="$(mktemp -d)"; \
+# https://www.google.com/linuxrepositories/
+	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC EC91 7721 F63B D38B 4796'; \
+	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" go.tgz.asc; \
+	\
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+	if [ -n "$build" ]; then \
+		savedAptMark="$(apt-mark showmanual)"; \
+		apt-get update; \
+		apt-get install -y --no-install-recommends golang-go; \
+		\
+		( \
+			cd /usr/local/go/src; \
+# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
+			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
+			./make.bash; \
+		); \
+		\
+		apt-mark auto '.*' > /dev/null; \
+		apt-mark manual $savedAptMark > /dev/null; \
+		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+		rm -rf /var/lib/apt/lists/*; \
+		\
+# pre-compile the standard library, just like the official binary release tarballs do
+		go install std; \
+# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
+#		go install -race std; \
+		\
+# remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
+		rm -rf \
+			/usr/local/go/pkg/*/cmd \
+			/usr/local/go/pkg/bootstrap \
+			/usr/local/go/pkg/obj \
+			/usr/local/go/pkg/tool/*/api \
+			/usr/local/go/pkg/tool/*/go_bootstrap \
+			/usr/local/go/src/cmd/dist/dist \
+		; \
+	fi; \
+	\
+	go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -128,9 +128,9 @@ for version; do
 				variantArches="${parentRepoToArches[$variantParent]}"
 
 				if [ "$variant" = 'stretch' ]; then
-					# stretch's "golang-go" package doesn't include GOARM for arm32v5
+					# stretch's "golang-go" package fails to build (TODO try backports?)
 					variantArches="$(sed <<<" $variantArches " -e 's/ arm32v5 / /g')"
-					# ... and "gccgo" in stretch can't build mips64le
+					# "gccgo" in stretch can't build mips64le
 					variantArches="$(sed <<<" $variantArches " -e 's/ mips64le / /g')"
 				fi
 				;;

--- a/versions.json
+++ b/versions.json
@@ -86,6 +86,7 @@
     },
     "variants": [
       "buster",
+      "stretch",
       "alpine3.13",
       "alpine3.12",
       "windows/windowsservercore-1809",
@@ -181,6 +182,7 @@
     },
     "variants": [
       "buster",
+      "stretch",
       "alpine3.13",
       "alpine3.12",
       "windows/windowsservercore-1809",


### PR DESCRIPTION
Given the glibc ABI break between buster and stretch, it is thus inordinately difficult to build binaries that work on older distributions (binaries build on buster won't run on stretch, for example).

~~This also re-enables arm32v5 for the stretch images as we now set `GOARM` and friends explicitly for build scenarios.~~

Closes #344
Closes #351