### PR TITLE
Convert versions.sh to use official upstream JSON data and official download URLs

### DIFF
--- a/1.15/alpine3.12/Dockerfile
+++ b/1.15/alpine3.12/Dockerfile
@@ -54,7 +54,7 @@ RUN set -eux; \
 	esac; \
 	\
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
-	url='https://storage.googleapis.com/golang/go1.15.11.src.tar.gz'; \
+	url='https://dl.google.com/go/go1.15.11.src.tar.gz'; \
 	sha256='f25b2441d4c76cf63cde94d59bab237cc33e8a2a139040d904c8630f46d061e5'; \
 	\
 	wget -O go.tgz.asc "$url.asc"; \

--- a/1.15/alpine3.13/Dockerfile
+++ b/1.15/alpine3.13/Dockerfile
@@ -54,7 +54,7 @@ RUN set -eux; \
 	esac; \
 	\
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
-	url='https://storage.googleapis.com/golang/go1.15.11.src.tar.gz'; \
+	url='https://dl.google.com/go/go1.15.11.src.tar.gz'; \
 	sha256='f25b2441d4c76cf63cde94d59bab237cc33e8a2a139040d904c8630f46d061e5'; \
 	\
 	wget -O go.tgz.asc "$url.asc"; \

--- a/1.15/buster/Dockerfile
+++ b/1.15/buster/Dockerfile
@@ -25,33 +25,33 @@ RUN set -eux; \
 	url=; \
 	case "${dpkgArch##*-}" in \
 		'amd64') \
-			url='https://storage.googleapis.com/golang/go1.15.11.linux-amd64.tar.gz'; \
+			url='https://dl.google.com/go/go1.15.11.linux-amd64.tar.gz'; \
 			sha256='8825b72d74b14e82b54ba3697813772eb94add3abf70f021b6bdebe193ed01ec'; \
 			;; \
 		'armel') \
 			export GOARCH='arm' GOARM='5' GOOS='linux'; \
 			;; \
 		'armhf') \
-			url='https://storage.googleapis.com/golang/go1.15.11.linux-armv6l.tar.gz'; \
+			url='https://dl.google.com/go/go1.15.11.linux-armv6l.tar.gz'; \
 			sha256='dba11ed018fc7b5774ca996c4bdb847f8f9535cdc4932eb09a43c390813af4c9'; \
 			;; \
 		'arm64') \
-			url='https://storage.googleapis.com/golang/go1.15.11.linux-arm64.tar.gz'; \
+			url='https://dl.google.com/go/go1.15.11.linux-arm64.tar.gz'; \
 			sha256='bfc8f07945296e97c6d28c7999d86b5cab51c7a87eb2b22ca6781c41a6bb6f2d'; \
 			;; \
 		'i386') \
-			url='https://storage.googleapis.com/golang/go1.15.11.linux-386.tar.gz'; \
+			url='https://dl.google.com/go/go1.15.11.linux-386.tar.gz'; \
 			sha256='2de51fc6873d8b688d7451cfc87443ef49404af98bbab9c8a36fb6c4bc95e4de'; \
 			;; \
 		'mips64el') \
 			export GOARCH='mips64le' GOOS='linux'; \
 			;; \
 		'ppc64el') \
-			url='https://storage.googleapis.com/golang/go1.15.11.linux-ppc64le.tar.gz'; \
+			url='https://dl.google.com/go/go1.15.11.linux-ppc64le.tar.gz'; \
 			sha256='4916ef0fc4c40db2dcc503a3473b325ed21d100cc77f1cc7e0a3aede19eec628'; \
 			;; \
 		's390x') \
-			url='https://storage.googleapis.com/golang/go1.15.11.linux-s390x.tar.gz'; \
+			url='https://dl.google.com/go/go1.15.11.linux-s390x.tar.gz'; \
 			sha256='2fb25504fa525e24dbba7e8e7fa2d91c42c66272dc176d5270dec77099124c75'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$dpkgArch' (likely packaging update needed)"; exit 1 ;; \
@@ -60,7 +60,7 @@ RUN set -eux; \
 	if [ -z "$url" ]; then \
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
 		build=1; \
-		url='https://storage.googleapis.com/golang/go1.15.11.src.tar.gz'; \
+		url='https://dl.google.com/go/go1.15.11.src.tar.gz'; \
 		sha256='f25b2441d4c76cf63cde94d59bab237cc33e8a2a139040d904c8630f46d061e5'; \
 		echo >&2; \
 		echo >&2 "warning: current architecture ($dpkgArch) does not have a corresponding Go binary release; will be building from source"; \

--- a/1.15/stretch/Dockerfile
+++ b/1.15/stretch/Dockerfile
@@ -25,33 +25,33 @@ RUN set -eux; \
 	url=; \
 	case "${dpkgArch##*-}" in \
 		'amd64') \
-			url='https://storage.googleapis.com/golang/go1.15.11.linux-amd64.tar.gz'; \
+			url='https://dl.google.com/go/go1.15.11.linux-amd64.tar.gz'; \
 			sha256='8825b72d74b14e82b54ba3697813772eb94add3abf70f021b6bdebe193ed01ec'; \
 			;; \
 		'armel') \
 			export GOARCH='arm' GOARM='5' GOOS='linux'; \
 			;; \
 		'armhf') \
-			url='https://storage.googleapis.com/golang/go1.15.11.linux-armv6l.tar.gz'; \
+			url='https://dl.google.com/go/go1.15.11.linux-armv6l.tar.gz'; \
 			sha256='dba11ed018fc7b5774ca996c4bdb847f8f9535cdc4932eb09a43c390813af4c9'; \
 			;; \
 		'arm64') \
-			url='https://storage.googleapis.com/golang/go1.15.11.linux-arm64.tar.gz'; \
+			url='https://dl.google.com/go/go1.15.11.linux-arm64.tar.gz'; \
 			sha256='bfc8f07945296e97c6d28c7999d86b5cab51c7a87eb2b22ca6781c41a6bb6f2d'; \
 			;; \
 		'i386') \
-			url='https://storage.googleapis.com/golang/go1.15.11.linux-386.tar.gz'; \
+			url='https://dl.google.com/go/go1.15.11.linux-386.tar.gz'; \
 			sha256='2de51fc6873d8b688d7451cfc87443ef49404af98bbab9c8a36fb6c4bc95e4de'; \
 			;; \
 		'mips64el') \
 			export GOARCH='mips64le' GOOS='linux'; \
 			;; \
 		'ppc64el') \
-			url='https://storage.googleapis.com/golang/go1.15.11.linux-ppc64le.tar.gz'; \
+			url='https://dl.google.com/go/go1.15.11.linux-ppc64le.tar.gz'; \
 			sha256='4916ef0fc4c40db2dcc503a3473b325ed21d100cc77f1cc7e0a3aede19eec628'; \
 			;; \
 		's390x') \
-			url='https://storage.googleapis.com/golang/go1.15.11.linux-s390x.tar.gz'; \
+			url='https://dl.google.com/go/go1.15.11.linux-s390x.tar.gz'; \
 			sha256='2fb25504fa525e24dbba7e8e7fa2d91c42c66272dc176d5270dec77099124c75'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$dpkgArch' (likely packaging update needed)"; exit 1 ;; \
@@ -60,7 +60,7 @@ RUN set -eux; \
 	if [ -z "$url" ]; then \
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
 		build=1; \
-		url='https://storage.googleapis.com/golang/go1.15.11.src.tar.gz'; \
+		url='https://dl.google.com/go/go1.15.11.src.tar.gz'; \
 		sha256='f25b2441d4c76cf63cde94d59bab237cc33e8a2a139040d904c8630f46d061e5'; \
 		echo >&2; \
 		echo >&2 "warning: current architecture ($dpkgArch) does not have a corresponding Go binary release; will be building from source"; \

--- a/1.15/windows/windowsservercore-1809/Dockerfile
+++ b/1.15/windows/windowsservercore-1809/Dockerfile
@@ -54,7 +54,7 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 
 ENV GOLANG_VERSION 1.15.11
 
-RUN $url = 'https://storage.googleapis.com/golang/go1.15.11.windows-amd64.zip'; \
+RUN $url = 'https://dl.google.com/go/go1.15.11.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\

--- a/1.15/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/1.15/windows/windowsservercore-ltsc2016/Dockerfile
@@ -54,7 +54,7 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 
 ENV GOLANG_VERSION 1.15.11
 
-RUN $url = 'https://storage.googleapis.com/golang/go1.15.11.windows-amd64.zip'; \
+RUN $url = 'https://dl.google.com/go/go1.15.11.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\

--- a/1.16/alpine3.12/Dockerfile
+++ b/1.16/alpine3.12/Dockerfile
@@ -54,7 +54,7 @@ RUN set -eux; \
 	esac; \
 	\
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
-	url='https://storage.googleapis.com/golang/go1.16.3.src.tar.gz'; \
+	url='https://dl.google.com/go/go1.16.3.src.tar.gz'; \
 	sha256='b298d29de9236ca47a023e382313bcc2d2eed31dfa706b60a04103ce83a71a25'; \
 	\
 	wget -O go.tgz.asc "$url.asc"; \

--- a/1.16/alpine3.13/Dockerfile
+++ b/1.16/alpine3.13/Dockerfile
@@ -54,7 +54,7 @@ RUN set -eux; \
 	esac; \
 	\
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
-	url='https://storage.googleapis.com/golang/go1.16.3.src.tar.gz'; \
+	url='https://dl.google.com/go/go1.16.3.src.tar.gz'; \
 	sha256='b298d29de9236ca47a023e382313bcc2d2eed31dfa706b60a04103ce83a71a25'; \
 	\
 	wget -O go.tgz.asc "$url.asc"; \

--- a/1.16/buster/Dockerfile
+++ b/1.16/buster/Dockerfile
@@ -25,33 +25,33 @@ RUN set -eux; \
 	url=; \
 	case "${dpkgArch##*-}" in \
 		'amd64') \
-			url='https://storage.googleapis.com/golang/go1.16.3.linux-amd64.tar.gz'; \
+			url='https://dl.google.com/go/go1.16.3.linux-amd64.tar.gz'; \
 			sha256='951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2'; \
 			;; \
 		'armel') \
 			export GOARCH='arm' GOARM='5' GOOS='linux'; \
 			;; \
 		'armhf') \
-			url='https://storage.googleapis.com/golang/go1.16.3.linux-armv6l.tar.gz'; \
+			url='https://dl.google.com/go/go1.16.3.linux-armv6l.tar.gz'; \
 			sha256='0dae30385e3564a557dac7f12a63eedc73543e6da0f6017990e214ce8cc8797c'; \
 			;; \
 		'arm64') \
-			url='https://storage.googleapis.com/golang/go1.16.3.linux-arm64.tar.gz'; \
+			url='https://dl.google.com/go/go1.16.3.linux-arm64.tar.gz'; \
 			sha256='566b1d6f17d2bc4ad5f81486f0df44f3088c3ed47a3bec4099d8ed9939e90d5d'; \
 			;; \
 		'i386') \
-			url='https://storage.googleapis.com/golang/go1.16.3.linux-386.tar.gz'; \
+			url='https://dl.google.com/go/go1.16.3.linux-386.tar.gz'; \
 			sha256='48b2d1481db756c88c18b1f064dbfc3e265ce4a775a23177ca17e25d13a24c5d'; \
 			;; \
 		'mips64el') \
 			export GOARCH='mips64le' GOOS='linux'; \
 			;; \
 		'ppc64el') \
-			url='https://storage.googleapis.com/golang/go1.16.3.linux-ppc64le.tar.gz'; \
+			url='https://dl.google.com/go/go1.16.3.linux-ppc64le.tar.gz'; \
 			sha256='5eb046bbbbc7fe2591846a4303884cb5a01abb903e3e61e33459affe7874e811'; \
 			;; \
 		's390x') \
-			url='https://storage.googleapis.com/golang/go1.16.3.linux-s390x.tar.gz'; \
+			url='https://dl.google.com/go/go1.16.3.linux-s390x.tar.gz'; \
 			sha256='3e8bd7bde533a73fd6fa75b5288678ef397e76c198cfb26b8ae086035383b1cf'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$dpkgArch' (likely packaging update needed)"; exit 1 ;; \
@@ -60,7 +60,7 @@ RUN set -eux; \
 	if [ -z "$url" ]; then \
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
 		build=1; \
-		url='https://storage.googleapis.com/golang/go1.16.3.src.tar.gz'; \
+		url='https://dl.google.com/go/go1.16.3.src.tar.gz'; \
 		sha256='b298d29de9236ca47a023e382313bcc2d2eed31dfa706b60a04103ce83a71a25'; \
 		echo >&2; \
 		echo >&2 "warning: current architecture ($dpkgArch) does not have a corresponding Go binary release; will be building from source"; \

--- a/1.16/stretch/Dockerfile
+++ b/1.16/stretch/Dockerfile
@@ -25,33 +25,33 @@ RUN set -eux; \
 	url=; \
 	case "${dpkgArch##*-}" in \
 		'amd64') \
-			url='https://storage.googleapis.com/golang/go1.16.3.linux-amd64.tar.gz'; \
+			url='https://dl.google.com/go/go1.16.3.linux-amd64.tar.gz'; \
 			sha256='951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2'; \
 			;; \
 		'armel') \
 			export GOARCH='arm' GOARM='5' GOOS='linux'; \
 			;; \
 		'armhf') \
-			url='https://storage.googleapis.com/golang/go1.16.3.linux-armv6l.tar.gz'; \
+			url='https://dl.google.com/go/go1.16.3.linux-armv6l.tar.gz'; \
 			sha256='0dae30385e3564a557dac7f12a63eedc73543e6da0f6017990e214ce8cc8797c'; \
 			;; \
 		'arm64') \
-			url='https://storage.googleapis.com/golang/go1.16.3.linux-arm64.tar.gz'; \
+			url='https://dl.google.com/go/go1.16.3.linux-arm64.tar.gz'; \
 			sha256='566b1d6f17d2bc4ad5f81486f0df44f3088c3ed47a3bec4099d8ed9939e90d5d'; \
 			;; \
 		'i386') \
-			url='https://storage.googleapis.com/golang/go1.16.3.linux-386.tar.gz'; \
+			url='https://dl.google.com/go/go1.16.3.linux-386.tar.gz'; \
 			sha256='48b2d1481db756c88c18b1f064dbfc3e265ce4a775a23177ca17e25d13a24c5d'; \
 			;; \
 		'mips64el') \
 			export GOARCH='mips64le' GOOS='linux'; \
 			;; \
 		'ppc64el') \
-			url='https://storage.googleapis.com/golang/go1.16.3.linux-ppc64le.tar.gz'; \
+			url='https://dl.google.com/go/go1.16.3.linux-ppc64le.tar.gz'; \
 			sha256='5eb046bbbbc7fe2591846a4303884cb5a01abb903e3e61e33459affe7874e811'; \
 			;; \
 		's390x') \
-			url='https://storage.googleapis.com/golang/go1.16.3.linux-s390x.tar.gz'; \
+			url='https://dl.google.com/go/go1.16.3.linux-s390x.tar.gz'; \
 			sha256='3e8bd7bde533a73fd6fa75b5288678ef397e76c198cfb26b8ae086035383b1cf'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$dpkgArch' (likely packaging update needed)"; exit 1 ;; \
@@ -60,7 +60,7 @@ RUN set -eux; \
 	if [ -z "$url" ]; then \
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
 		build=1; \
-		url='https://storage.googleapis.com/golang/go1.16.3.src.tar.gz'; \
+		url='https://dl.google.com/go/go1.16.3.src.tar.gz'; \
 		sha256='b298d29de9236ca47a023e382313bcc2d2eed31dfa706b60a04103ce83a71a25'; \
 		echo >&2; \
 		echo >&2 "warning: current architecture ($dpkgArch) does not have a corresponding Go binary release; will be building from source"; \

--- a/1.16/windows/windowsservercore-1809/Dockerfile
+++ b/1.16/windows/windowsservercore-1809/Dockerfile
@@ -54,7 +54,7 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 
 ENV GOLANG_VERSION 1.16.3
 
-RUN $url = 'https://storage.googleapis.com/golang/go1.16.3.windows-amd64.zip'; \
+RUN $url = 'https://dl.google.com/go/go1.16.3.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\

--- a/1.16/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/1.16/windows/windowsservercore-ltsc2016/Dockerfile
@@ -54,7 +54,7 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 
 ENV GOLANG_VERSION 1.16.3
 
-RUN $url = 'https://storage.googleapis.com/golang/go1.16.3.windows-amd64.zip'; \
+RUN $url = 'https://dl.google.com/go/go1.16.3.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -26,6 +26,7 @@ RUN set -eux; \
 {{
 	[
 		.arches | to_entries[]
+		| select(.value.supported)
 		| .key as $bashbrewArch
 		| (
 			{

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -21,6 +21,7 @@ RUN set -eux; \
 {{
 	[
 		.arches | to_entries[]
+		| select(.value.supported)
 		| .key as $bashbrewArch
 		| (
 			{

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -136,6 +136,20 @@ for version; do
 				;;
 		esac
 
+		# cross-reference with supported architectures
+		for arch in $variantArches; do
+			if ! jq -e --arg arch "$arch" '.[env.version].arches[$arch].supported' versions.json &> /dev/null; then
+				variantArches="$(sed <<<" $variantArches " -e "s/ $arch / /g")"
+			fi
+		done
+		# TODO rewrite this whole loop into a single jq expression :)
+		variantArches="${variantArches% }"
+		variantArches="${variantArches# }"
+		if [ -z "$variantArches" ]; then
+			echo >&2 "error: '$dir' has no supported architectures!"
+			exit 1
+		fi
+
 		sharedTags=()
 		for windowsShared in windowsservercore nanoserver; do
 			if [[ "$variant" == "$windowsShared"* ]]; then

--- a/versions.json
+++ b/versions.json
@@ -7,21 +7,26 @@
           "GOOS": "linux"
         },
         "sha256": "8825b72d74b14e82b54ba3697813772eb94add3abf70f021b6bdebe193ed01ec",
-        "url": "https://storage.googleapis.com/golang/go1.15.11.linux-amd64.tar.gz"
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.15.11.linux-amd64.tar.gz"
       },
       "arm32v5": {
         "env": {
           "GOARCH": "arm",
           "GOARM": "5",
           "GOOS": "linux"
-        }
+        },
+        "supported": true
       },
       "arm32v6": {
         "env": {
           "GOARCH": "arm",
           "GOARM": "6",
           "GOOS": "linux"
-        }
+        },
+        "sha256": "dba11ed018fc7b5774ca996c4bdb847f8f9535cdc4932eb09a43c390813af4c9",
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.15.11.linux-armv6l.tar.gz"
       },
       "arm32v7": {
         "env": {
@@ -30,7 +35,8 @@
           "GOOS": "linux"
         },
         "sha256": "dba11ed018fc7b5774ca996c4bdb847f8f9535cdc4932eb09a43c390813af4c9",
-        "url": "https://storage.googleapis.com/golang/go1.15.11.linux-armv6l.tar.gz"
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.15.11.linux-armv6l.tar.gz"
       },
       "arm64v8": {
         "env": {
@@ -38,7 +44,35 @@
           "GOOS": "linux"
         },
         "sha256": "bfc8f07945296e97c6d28c7999d86b5cab51c7a87eb2b22ca6781c41a6bb6f2d",
-        "url": "https://storage.googleapis.com/golang/go1.15.11.linux-arm64.tar.gz"
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.15.11.linux-arm64.tar.gz"
+      },
+      "darwin-amd64": {
+        "env": {
+          "GOARCH": "amd64",
+          "GOOS": "darwin"
+        },
+        "sha256": "651c78408b2c047b7ccccb6b244c5de9eab927c87594ff6bd9540d43c9706671",
+        "supported": false,
+        "url": "https://dl.google.com/go/go1.15.11.darwin-amd64.tar.gz"
+      },
+      "freebsd-amd64": {
+        "env": {
+          "GOARCH": "amd64",
+          "GOOS": "freebsd"
+        },
+        "sha256": "38fb5516e86934dc385d1b06433692034f38ed38117e8017e211a0efe55ed44e",
+        "supported": false,
+        "url": "https://dl.google.com/go/go1.15.11.freebsd-amd64.tar.gz"
+      },
+      "freebsd-i386": {
+        "env": {
+          "GOARCH": "386",
+          "GOOS": "freebsd"
+        },
+        "sha256": "c9ac9e8e12b9a4639d8a164815d2ccab86f7c1534672c1d03933e7180d2ace5d",
+        "supported": false,
+        "url": "https://dl.google.com/go/go1.15.11.freebsd-386.tar.gz"
       },
       "i386": {
         "env": {
@@ -47,13 +81,15 @@
           "GOOS": "linux"
         },
         "sha256": "2de51fc6873d8b688d7451cfc87443ef49404af98bbab9c8a36fb6c4bc95e4de",
-        "url": "https://storage.googleapis.com/golang/go1.15.11.linux-386.tar.gz"
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.15.11.linux-386.tar.gz"
       },
       "mips64le": {
         "env": {
           "GOARCH": "mips64le",
           "GOOS": "linux"
-        }
+        },
+        "supported": true
       },
       "ppc64le": {
         "env": {
@@ -61,7 +97,8 @@
           "GOOS": "linux"
         },
         "sha256": "4916ef0fc4c40db2dcc503a3473b325ed21d100cc77f1cc7e0a3aede19eec628",
-        "url": "https://storage.googleapis.com/golang/go1.15.11.linux-ppc64le.tar.gz"
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.15.11.linux-ppc64le.tar.gz"
       },
       "s390x": {
         "env": {
@@ -69,11 +106,13 @@
           "GOOS": "linux"
         },
         "sha256": "2fb25504fa525e24dbba7e8e7fa2d91c42c66272dc176d5270dec77099124c75",
-        "url": "https://storage.googleapis.com/golang/go1.15.11.linux-s390x.tar.gz"
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.15.11.linux-s390x.tar.gz"
       },
       "src": {
         "sha256": "f25b2441d4c76cf63cde94d59bab237cc33e8a2a139040d904c8630f46d061e5",
-        "url": "https://storage.googleapis.com/golang/go1.15.11.src.tar.gz"
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.15.11.src.tar.gz"
       },
       "windows-amd64": {
         "env": {
@@ -81,7 +120,17 @@
           "GOOS": "windows"
         },
         "sha256": "56f63de17cd739287de6d9f3cfdad3b781ad3e4a18aae20ece994ee97c1819fd",
-        "url": "https://storage.googleapis.com/golang/go1.15.11.windows-amd64.zip"
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.15.11.windows-amd64.zip"
+      },
+      "windows-i386": {
+        "env": {
+          "GOARCH": "386",
+          "GOOS": "windows"
+        },
+        "sha256": "b0a64a2a2dedefd1559acf866e393c8e00294dbde113875ee9d8cf3561886123",
+        "supported": false,
+        "url": "https://dl.google.com/go/go1.15.11.windows-386.zip"
       }
     },
     "variants": [
@@ -103,21 +152,26 @@
           "GOOS": "linux"
         },
         "sha256": "951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2",
-        "url": "https://storage.googleapis.com/golang/go1.16.3.linux-amd64.tar.gz"
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.16.3.linux-amd64.tar.gz"
       },
       "arm32v5": {
         "env": {
           "GOARCH": "arm",
           "GOARM": "5",
           "GOOS": "linux"
-        }
+        },
+        "supported": true
       },
       "arm32v6": {
         "env": {
           "GOARCH": "arm",
           "GOARM": "6",
           "GOOS": "linux"
-        }
+        },
+        "sha256": "0dae30385e3564a557dac7f12a63eedc73543e6da0f6017990e214ce8cc8797c",
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.16.3.linux-armv6l.tar.gz"
       },
       "arm32v7": {
         "env": {
@@ -126,7 +180,8 @@
           "GOOS": "linux"
         },
         "sha256": "0dae30385e3564a557dac7f12a63eedc73543e6da0f6017990e214ce8cc8797c",
-        "url": "https://storage.googleapis.com/golang/go1.16.3.linux-armv6l.tar.gz"
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.16.3.linux-armv6l.tar.gz"
       },
       "arm64v8": {
         "env": {
@@ -134,7 +189,44 @@
           "GOOS": "linux"
         },
         "sha256": "566b1d6f17d2bc4ad5f81486f0df44f3088c3ed47a3bec4099d8ed9939e90d5d",
-        "url": "https://storage.googleapis.com/golang/go1.16.3.linux-arm64.tar.gz"
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.16.3.linux-arm64.tar.gz"
+      },
+      "darwin-amd64": {
+        "env": {
+          "GOARCH": "amd64",
+          "GOOS": "darwin"
+        },
+        "sha256": "6bb1cf421f8abc2a9a4e39140b7397cdae6aca3e8d36dcff39a1a77f4f1170ac",
+        "supported": false,
+        "url": "https://dl.google.com/go/go1.16.3.darwin-amd64.tar.gz"
+      },
+      "darwin-arm64v8": {
+        "env": {
+          "GOARCH": "arm64",
+          "GOOS": "darwin"
+        },
+        "sha256": "f4e96bbcd5d2d1942f5b55d9e4ab19564da4fad192012f6d7b0b9b055ba4208f",
+        "supported": false,
+        "url": "https://dl.google.com/go/go1.16.3.darwin-arm64.tar.gz"
+      },
+      "freebsd-amd64": {
+        "env": {
+          "GOARCH": "amd64",
+          "GOOS": "freebsd"
+        },
+        "sha256": "ffbd920b309e62e807457b11d80e8c17fefe3ef6de423aaba4b1e270b2ca4c3d",
+        "supported": false,
+        "url": "https://dl.google.com/go/go1.16.3.freebsd-amd64.tar.gz"
+      },
+      "freebsd-i386": {
+        "env": {
+          "GOARCH": "386",
+          "GOOS": "freebsd"
+        },
+        "sha256": "31ecd11d497684fa8b0f01ba784590c4c760943665fdc4fe0adaa1405c71736c",
+        "supported": false,
+        "url": "https://dl.google.com/go/go1.16.3.freebsd-386.tar.gz"
       },
       "i386": {
         "env": {
@@ -143,13 +235,15 @@
           "GOOS": "linux"
         },
         "sha256": "48b2d1481db756c88c18b1f064dbfc3e265ce4a775a23177ca17e25d13a24c5d",
-        "url": "https://storage.googleapis.com/golang/go1.16.3.linux-386.tar.gz"
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.16.3.linux-386.tar.gz"
       },
       "mips64le": {
         "env": {
           "GOARCH": "mips64le",
           "GOOS": "linux"
-        }
+        },
+        "supported": true
       },
       "ppc64le": {
         "env": {
@@ -157,7 +251,8 @@
           "GOOS": "linux"
         },
         "sha256": "5eb046bbbbc7fe2591846a4303884cb5a01abb903e3e61e33459affe7874e811",
-        "url": "https://storage.googleapis.com/golang/go1.16.3.linux-ppc64le.tar.gz"
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.16.3.linux-ppc64le.tar.gz"
       },
       "s390x": {
         "env": {
@@ -165,11 +260,13 @@
           "GOOS": "linux"
         },
         "sha256": "3e8bd7bde533a73fd6fa75b5288678ef397e76c198cfb26b8ae086035383b1cf",
-        "url": "https://storage.googleapis.com/golang/go1.16.3.linux-s390x.tar.gz"
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.16.3.linux-s390x.tar.gz"
       },
       "src": {
         "sha256": "b298d29de9236ca47a023e382313bcc2d2eed31dfa706b60a04103ce83a71a25",
-        "url": "https://storage.googleapis.com/golang/go1.16.3.src.tar.gz"
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.16.3.src.tar.gz"
       },
       "windows-amd64": {
         "env": {
@@ -177,7 +274,17 @@
           "GOOS": "windows"
         },
         "sha256": "a4400345135b36cb7942e52bbaf978b66814738b855eeff8de879a09fd99de7f",
-        "url": "https://storage.googleapis.com/golang/go1.16.3.windows-amd64.zip"
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.16.3.windows-amd64.zip"
+      },
+      "windows-i386": {
+        "env": {
+          "GOARCH": "386",
+          "GOOS": "windows"
+        },
+        "sha256": "a3c16e1531bf9726f47911c4a9ed7cb665a6207a51c44f10ebad4db63b4bcc5a",
+        "supported": false,
+        "url": "https://dl.google.com/go/go1.16.3.windows-386.zip"
       }
     },
     "variants": [

--- a/versions.sh
+++ b/versions.sh
@@ -2,18 +2,22 @@
 set -Eeuo pipefail
 
 # see https://golang.org/dl/
-declare -A golangArches=(
-	['amd64']='linux-amd64'
-	['arm32v7']='linux-armv6l' # the published binaries only support glibc, which translates to Debian, so the "correct" binary for v7 is v6 (TODO find some way to reasonably benchmark the compiler on a proper v7 chip and determine whether recompiling for GOARM=7 is worthwhile)
-	['arm64v8']='linux-arm64'
-	['i386']='linux-386'
-	['ppc64le']='linux-ppc64le'
-	['s390x']='linux-s390x'
-	['windows-amd64']='windows-amd64'
+potentiallySupportedArches=(
+	amd64
+	arm32v5
+	arm32v6
+	arm32v7
+	arm64v8
+	i386
+	mips64le
+	ppc64le
+	s390x
+	windows-amd64
 
 	# special case (fallback)
-	['src']='src'
+	src
 )
+potentiallySupportedArches="$(jq -sRc <<<"${potentiallySupportedArches[*]}" 'rtrimstr("\n") | split(" ")')"
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
@@ -26,160 +30,121 @@ else
 fi
 versions=( "${versions[@]%/}" )
 
-# https://github.com/golang/go/issues/13220
-allGoVersions='{}'
-apiBaseUrl='https://www.googleapis.com/storage/v1/b/golang/o?fields=nextPageToken,items%2Fname'
-pageToken=
-while [ "$pageToken" != 'null' ]; do
-	page="$(curl -fsSL "$apiBaseUrl&pageToken=$pageToken")"
-	# now that we have this page's data, get ready for the next request
-	pageToken="$(jq <<<"$page" -r '.nextPageToken')"
+# https://github.com/golang/go/issues/23746
+goVersions="$(
+	wget -qO- 'https://golang.org/dl/?mode=json' | jq -c --argjson potentiallySupportedArches "$potentiallySupportedArches" '
+		[
+			.[]
+			| ( .version | ltrimstr("go") ) as $version
+			| ( $version | sub("^(?<m>[0-9]+[.][0-9]+).*$"; "\(.m)") ) as $major
+			| {
+				version: $version,
+				major: ( $major + if .stable then "" else "-rc" end ),
+				arches: ([
+					.files[]
+					| select(.kind == "archive" or .kind == "source")
+					| (
+						if .kind == "source" then
+							"src"
+						else
+							if .os != "linux" then
+								.os + "-"
+							else "" end
+							+ (
+								.arch
+								| sub("^386$"; "i386")
+								| sub("^arm64$"; "arm64v8")
+								| sub("^armv(?<v>[0-9]+)l?$"; "arm32v\(.v)")
+							)
+						end
+					) as $bashbrewArch
+					| {
+						( $bashbrewArch ): (
+							{
+								sha256: .sha256,
+								url: ("https://dl.google.com/go/" + .filename),
+								supported: ($potentiallySupportedArches | index($bashbrewArch) != null),
+							} + if $bashbrewArch == "src" then {} else {
+								env: (
+									{ GOOS: .os, GOARCH: .arch }
+									+ if .arch == "386" and .os == "linux" then
+										# i386 in Debian is non-SSE2, Alpine appears to be similar (but interesting, not FreeBSD?)
+										{ GO386: (if $major == "1.15" then "387" else "softfloat" end) }
+									elif $bashbrewArch | startswith("arm32v") then
+										{ GOARCH: "arm", GOARM: ($bashbrewArch | ltrimstr("arm32v")) }
+									else {} end
+								),
+							} end
+						),
+					}
+				] | add)
+			}
 
-	# for each API page, collect the "version => arches" pairs we find
-	goVersions="$(
-		jq <<<"$page" -r '
-			[
-				.items as $items
-				| $items[].name
-				| match("^go([0-9].*)[.](src|(linux|windows)-[^.]+)[.](tar[.]gz|zip)$")
-				| .captures[0].string as $version
-				| .captures[1].string as $arch
-				| { version: $version, arch: $arch }
-			] | reduce .[] as $o (
-				{};
-				.[$o.version] += [ $o.arch ]
-			)
-		'
-	)"
+			# the published binaries only support glibc, which translates to Debian, so the "correct" binary for v7 is v6 (TODO find some way to reasonably benchmark the compiler on a proper v7 chip and determine whether recompiling for GOARM=7 is worthwhile)
+			| if (.arches | has("arm32v7") | not) and (.arches | has("arm32v6")) then
+				.arches["arm32v7"] = (.arches["arm32v6"] | .env.GOARM = "7")
+			else . end
 
-	# ... and aggregate them together into a single object of "version => arches" pairs
-	allGoVersions="$(
-		jq <<<"$allGoVersions"$'\n'"$goVersions" -cs '
-			map(to_entries) | add
-			| reduce .[] as $o (
-				{};
-				.[$o.key] = (
-					$o.value + .[$o.key]
-					| unique
+			| ( $potentiallySupportedArches - (.arches | keys) ) as $missingArches
+			| .arches = ([
+				.arches, (
+					$missingArches[]
+					| {
+						(.): {
+							supported: true,
+							env: (
+								{
+									GOOS: "linux",
+									GOARCH: .,
+								}
+								+ if startswith("arm32v") then
+									{ GOARCH: "arm", GOARM: ltrimstr("arm32v") }
+								else {} end
+							)
+						},
+					}
 				)
-			)
-		'
-	)"
-done
+			] | add)
+		]
+	'
+)"
 
 for version in "${versions[@]}"; do
-	rcVersion="${version%-rc}"
-	rcRegex='^[^a-z]*$'
-	if [ "$rcVersion" != "$version" ]; then
-		# beta, rc, etc
-		rcRegex='[a-z]+[0-9]*$'
-	fi
+	export version
 
-	export rcVersion rcRegex
-	fullVersion="$(
-		jq <<<"$allGoVersions" -r '
-			. as $map
-			| keys[] | select(
-				startswith(env.rcVersion)
-				and (
-					ltrimstr(env.rcVersion)
-					| test(env.rcRegex)
-				)
-				and ($map[.] | index("src"))
-			)
-		' | sort -rV | head -1
-	)"
-	if [ -z "$fullVersion" ]; then
+	if \
+		! goJson="$(jq <<<"$goVersions" -c '[ .[] | select(.major == env.version) ][0]')" \
+		|| ! fullVersion="$(jq <<<"$goJson" -r '.version')" \
+		|| [ -z "$fullVersion" ] \
+	; then
 		echo >&2 "warning: cannot find full version for $version"
 		continue
 	fi
 
 	echo "$version: $fullVersion"
 
-	export fullVersion
-	doc="$(jq -nc '
-		{
-			version: env.fullVersion,
-			arches: (
-				[
-					# the full list of *potentially* supported architectures
-					"amd64",
-					"arm32v5",
-					"arm32v6",
-					"arm32v7",
-					"arm64v8",
-					"i386",
-					"mips64le",
-					"ppc64le",
-					"s390x",
-					"windows-amd64"
-				] | map({
-					(.): {
-						env: (
-							{ GOOS: "linux" }
-							+ if startswith("windows-") then
-								{ GOOS: "windows", GOARCH: ltrimstr("windows-") }
-							elif. == "i386" then
-								{ GOARCH: "386", GO386: (if env.rcVersion == "1.15" then "387" else "softfloat" end) }
-							elif . == "arm64v8" then
-								{ GOARCH: "arm64" }
-							elif startswith("arm32v") then
-								{ GOARCH: "arm", GOARM: ltrimstr("arm32v") }
-							else
-								{ GOARCH: . }
-							end
-						),
-					},
-				}) | add
-			),
-			variants: [],
-		}
-	')"
+	doc="$(jq <<<"$goJson" -c '{
+		version: .version,
+		arches: .arches,
+		variants: [
+			"buster",
+			"stretch",
+			(
+				"3.13",
+				"3.12"
+			| "alpine" + .),
+			if .arches | has("windows-amd64") then
+				(
+					"1809",
+					"ltsc2016"
+				| "windows/windowsservercore-" + .),
+				(
+					"1809"
+				| "windows/nanoserver-" + .)
+			else empty end
+		],
+	}')"
 
-	arches="$(jq <<<"$allGoVersions" -c '.[env.fullVersion]')"
-
-	# loop over bashbrew arches, get sha256 for each one supported
-	for bashbrewArch in "${!golangArches[@]}"; do
-		arch="${golangArches[$bashbrewArch]}"
-		export arch
-		if jq <<<"$arches" -e 'index(env.arch) != null' > /dev/null; then
-			file="go${fullVersion}.$arch.$([[ "$arch" == windows-* ]] && echo 'zip' || echo 'tar.gz')"
-			url="https://storage.googleapis.com/golang/$file"
-			# https://github.com/golang/build/commit/24f7399f96feb8dd2fc54f064e47a886c2f8bb4a
-			if sha256="$(curl -fsSL "$url.sha256")"; then
-				export bashbrewArch arch url sha256
-				doc="$(
-					jq <<<"$doc" -c '.arches[env.bashbrewArch] += {
-						url: env.url,
-						sha256: env.sha256,
-					}'
-				)"
-			fi
-		fi
-	done
-
-	# order here controls the order of the library/ file
-	for variant in \
-		buster \
-		stretch \
-		\
-		alpine3.13 \
-		alpine3.12 \
-		alpine3.11 \
-		\
-		windows/windowsservercore-{1809,ltsc2016} \
-		windows/nanoserver-1809 \
-	; do
-		base="${variant%%/*}" # "buster", "windows", etc.
-		[ -d "$version/$base" ] || continue
-		if [ "$base" = 'windows' ] && ! jq <<<"$arches" -e 'index("windows-amd64")' > /dev/null; then
-			continue
-		fi
-		export variant
-		doc="$(jq <<<"$doc" -c '.variants += [ env.variant ]')"
-	done
-
-	export version
 	json="$(jq <<<"$json" -c --argjson doc "$doc" '.[env.version] = $doc')"
 done
 


### PR DESCRIPTION
After spending way more time on it than I probably should have, I managed to convert https://golang.org/dl/?mode=json almost directly into versions.json in a single `jq` invocation, but now with even more data than before.

This makes the script literally an order of magnitude faster (only a single external URL instead of many pages of download pagination + one per version+arch combo to download the sha256 files) -- from ~5s fully-cache-primed down to less than 0.5s.

This was inspired directly by https://github.com/travis-ci/gimme/pull/197 and the relevant comments there. :smile:

See also https://github.com/golang/go/issues/45603 and https://github.com/golang/go/issues/23746.