### PR TITLE
For Go 1.17+, move the Windows install to C:\Program Files\Go

### DIFF
--- a/1.15/windows/nanoserver-1809/Dockerfile
+++ b/1.15/windows/nanoserver-1809/Dockerfile
@@ -11,8 +11,9 @@ SHELL ["cmd", "/S", "/C"]
 # no Git installed (intentionally)
 #  -- Nano Server is "Windows Slim"
 
-# ideally, this would be C:\go to match Linux a bit closer, but C:\go is the recommended install path for Go itself on Windows
+# ideally, this would be C:\go to match Linux a bit closer, but C:\go was the default install path for Go itself on Windows
 ENV GOPATH C:\\gopath
+# (https://golang.org/cl/283600)
 
 # PATH isn't actually set in the Docker image, so we have to set it from within the container
 USER ContainerAdministrator
@@ -22,7 +23,8 @@ USER ContainerUser
 
 ENV GOLANG_VERSION 1.15.14
 
-COPY --from=golang:1.15.14-windowsservercore-1809 C:\\go C:\\go
+# Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
+COPY --from=golang:1.15.14-windowsservercore-1809 ["C:\\\\go","C:\\\\go"]
 RUN go version
 
 WORKDIR $GOPATH

--- a/1.15/windows/windowsservercore-1809/Dockerfile
+++ b/1.15/windows/windowsservercore-1809/Dockerfile
@@ -43,8 +43,9 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	\
 	Write-Host 'Complete.';
 
-# ideally, this would be C:\go to match Linux a bit closer, but C:\go is the recommended install path for Go itself on Windows
+# ideally, this would be C:\go to match Linux a bit closer, but C:\go was the default install path for Go itself on Windows
 ENV GOPATH C:\\gopath
+# (https://golang.org/cl/283600)
 
 # PATH isn't actually set in the Docker image, so we have to set it from within the container
 RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \

--- a/1.15/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/1.15/windows/windowsservercore-ltsc2016/Dockerfile
@@ -43,8 +43,9 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	\
 	Write-Host 'Complete.';
 
-# ideally, this would be C:\go to match Linux a bit closer, but C:\go is the recommended install path for Go itself on Windows
+# ideally, this would be C:\go to match Linux a bit closer, but C:\go was the default install path for Go itself on Windows
 ENV GOPATH C:\\gopath
+# (https://golang.org/cl/283600)
 
 # PATH isn't actually set in the Docker image, so we have to set it from within the container
 RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \

--- a/1.16/windows/nanoserver-1809/Dockerfile
+++ b/1.16/windows/nanoserver-1809/Dockerfile
@@ -11,8 +11,9 @@ SHELL ["cmd", "/S", "/C"]
 # no Git installed (intentionally)
 #  -- Nano Server is "Windows Slim"
 
-# ideally, this would be C:\go to match Linux a bit closer, but C:\go is the recommended install path for Go itself on Windows
+# ideally, this would be C:\go to match Linux a bit closer, but C:\go was the default install path for Go itself on Windows
 ENV GOPATH C:\\gopath
+# (https://golang.org/cl/283600)
 
 # PATH isn't actually set in the Docker image, so we have to set it from within the container
 USER ContainerAdministrator
@@ -22,7 +23,8 @@ USER ContainerUser
 
 ENV GOLANG_VERSION 1.16.6
 
-COPY --from=golang:1.16.6-windowsservercore-1809 C:\\go C:\\go
+# Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
+COPY --from=golang:1.16.6-windowsservercore-1809 ["C:\\\\go","C:\\\\go"]
 RUN go version
 
 WORKDIR $GOPATH

--- a/1.16/windows/windowsservercore-1809/Dockerfile
+++ b/1.16/windows/windowsservercore-1809/Dockerfile
@@ -43,8 +43,9 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	\
 	Write-Host 'Complete.';
 
-# ideally, this would be C:\go to match Linux a bit closer, but C:\go is the recommended install path for Go itself on Windows
+# ideally, this would be C:\go to match Linux a bit closer, but C:\go was the default install path for Go itself on Windows
 ENV GOPATH C:\\gopath
+# (https://golang.org/cl/283600)
 
 # PATH isn't actually set in the Docker image, so we have to set it from within the container
 RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \

--- a/1.16/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/1.16/windows/windowsservercore-ltsc2016/Dockerfile
@@ -43,8 +43,9 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	\
 	Write-Host 'Complete.';
 
-# ideally, this would be C:\go to match Linux a bit closer, but C:\go is the recommended install path for Go itself on Windows
+# ideally, this would be C:\go to match Linux a bit closer, but C:\go was the default install path for Go itself on Windows
 ENV GOPATH C:\\gopath
+# (https://golang.org/cl/283600)
 
 # PATH isn't actually set in the Docker image, so we have to set it from within the container
 RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \

--- a/1.17-rc/windows/nanoserver-1809/Dockerfile
+++ b/1.17-rc/windows/nanoserver-1809/Dockerfile
@@ -11,18 +11,20 @@ SHELL ["cmd", "/S", "/C"]
 # no Git installed (intentionally)
 #  -- Nano Server is "Windows Slim"
 
-# ideally, this would be C:\go to match Linux a bit closer, but C:\go is the recommended install path for Go itself on Windows
-ENV GOPATH C:\\gopath
+# for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
+ENV GOPATH C:\\go
+# HOWEVER, please note that it is the Go upstream intention to remove GOPATH support entirely: https://blog.golang.org/go116-module-changes
 
 # PATH isn't actually set in the Docker image, so we have to set it from within the container
 USER ContainerAdministrator
-RUN setx /m PATH "%GOPATH%\bin;C:\go\bin;%PATH%"
+RUN setx /m PATH "%GOPATH%\bin;C:\Program Files\Go\bin;%PATH%"
 USER ContainerUser
 # doing this first to share cache across versions more aggressively
 
 ENV GOLANG_VERSION 1.17rc1
 
-COPY --from=golang:1.17rc1-windowsservercore-1809 C:\\go C:\\go
+# Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
+COPY --from=golang:1.17rc1-windowsservercore-1809 ["C:\\\\Program Files\\\\Go","C:\\\\Program Files\\\\Go"]
 RUN go version
 
 WORKDIR $GOPATH

--- a/1.17-rc/windows/windowsservercore-1809/Dockerfile
+++ b/1.17-rc/windows/windowsservercore-1809/Dockerfile
@@ -43,11 +43,12 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	\
 	Write-Host 'Complete.';
 
-# ideally, this would be C:\go to match Linux a bit closer, but C:\go is the recommended install path for Go itself on Windows
-ENV GOPATH C:\\gopath
+# for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
+ENV GOPATH C:\\go
+# HOWEVER, please note that it is the Go upstream intention to remove GOPATH support entirely: https://blog.golang.org/go116-module-changes
 
 # PATH isn't actually set in the Docker image, so we have to set it from within the container
-RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
+RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 	Write-Host ('Updating PATH: {0}' -f $newPath); \
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
@@ -67,6 +68,9 @@ RUN $url = 'https://dl.google.com/go/go1.17rc1.windows-amd64.zip'; \
 	\
 	Write-Host 'Expanding ...'; \
 	Expand-Archive go.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Moving ...'; \
+	Move-Item -Path C:\go -Destination 'C:\Program Files\Go'; \
 	\
 	Write-Host 'Removing ...'; \
 	Remove-Item go.zip -Force; \

--- a/1.17-rc/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/1.17-rc/windows/windowsservercore-ltsc2016/Dockerfile
@@ -43,11 +43,12 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	\
 	Write-Host 'Complete.';
 
-# ideally, this would be C:\go to match Linux a bit closer, but C:\go is the recommended install path for Go itself on Windows
-ENV GOPATH C:\\gopath
+# for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
+ENV GOPATH C:\\go
+# HOWEVER, please note that it is the Go upstream intention to remove GOPATH support entirely: https://blog.golang.org/go116-module-changes
 
 # PATH isn't actually set in the Docker image, so we have to set it from within the container
-RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
+RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 	Write-Host ('Updating PATH: {0}' -f $newPath); \
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
@@ -67,6 +68,9 @@ RUN $url = 'https://dl.google.com/go/go1.17rc1.windows-amd64.zip'; \
 	\
 	Write-Host 'Expanding ...'; \
 	Expand-Archive go.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Moving ...'; \
+	Move-Item -Path C:\go -Destination 'C:\Program Files\Go'; \
 	\
 	Write-Host 'Removing ...'; \
 	Remove-Item go.zip -Force; \

--- a/Dockerfile-windows-nanoserver.template
+++ b/Dockerfile-windows-nanoserver.template
@@ -5,18 +5,39 @@ SHELL ["cmd", "/S", "/C"]
 # no Git installed (intentionally)
 #  -- Nano Server is "Windows Slim"
 
-# ideally, this would be C:\go to match Linux a bit closer, but C:\go is the recommended install path for Go itself on Windows
+{{
+	def install_directory:
+		if [ "1.15", "1.16" ] | index(env.version) then
+			"C:\\go"
+		else
+			"C:\\Program Files\\Go"
+		end
+-}}
+{{ if install_directory == "C:\\go" then ( -}}
+# ideally, this would be C:\go to match Linux a bit closer, but C:\go was the default install path for Go itself on Windows
 ENV GOPATH C:\\gopath
+# (https://golang.org/cl/283600)
+{{ ) else ( -}}
+# for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
+ENV GOPATH C:\\go
+# HOWEVER, please note that it is the Go upstream intention to remove GOPATH support entirely: https://blog.golang.org/go116-module-changes
+{{ ) end -}}
 
 # PATH isn't actually set in the Docker image, so we have to set it from within the container
 USER ContainerAdministrator
-RUN setx /m PATH "%GOPATH%\bin;C:\go\bin;%PATH%"
+RUN setx /m PATH "%GOPATH%\bin;{{ install_directory }}\bin;%PATH%"
 USER ContainerUser
 # doing this first to share cache across versions more aggressively
 
 ENV GOLANG_VERSION {{ .version }}
 
-COPY --from=golang:{{ .version }}-windowsservercore-{{ env.windowsRelease }} C:\\go C:\\go
+# Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
+COPY --from=golang:{{ .version }}-windowsservercore-{{ env.windowsRelease }} {{
+	install_directory
+	| gsub("\\\\"; "\\\\")
+	| [ . , . ]
+	| @json
+}}
 RUN go version
 
 WORKDIR $GOPATH

--- a/Dockerfile-windows-servercore.template
+++ b/Dockerfile-windows-servercore.template
@@ -37,11 +37,26 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	\
 	Write-Host 'Complete.';
 
-# ideally, this would be C:\go to match Linux a bit closer, but C:\go is the recommended install path for Go itself on Windows
+{{
+	def install_directory:
+		if [ "1.15", "1.16" ] | index(env.version) then
+			"C:\\go"
+		else
+			"C:\\Program Files\\Go"
+		end
+-}}
+{{ if install_directory == "C:\\go" then ( -}}
+# ideally, this would be C:\go to match Linux a bit closer, but C:\go was the default install path for Go itself on Windows
 ENV GOPATH C:\\gopath
+# (https://golang.org/cl/283600)
+{{ ) else ( -}}
+# for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
+ENV GOPATH C:\\go
+# HOWEVER, please note that it is the Go upstream intention to remove GOPATH support entirely: https://blog.golang.org/go116-module-changes
+{{ ) end -}}
 
 # PATH isn't actually set in the Docker image, so we have to set it from within the container
-RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
+RUN $newPath = ('{0}\bin;{{ install_directory }}\bin;{1}' -f $env:GOPATH, $env:PATH); \
 	Write-Host ('Updating PATH: {0}' -f $newPath); \
 	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
 # doing this first to share cache across versions more aggressively
@@ -61,6 +76,11 @@ RUN $url = '{{ .arches["windows-amd64"].url }}'; \
 	\
 	Write-Host 'Expanding ...'; \
 	Expand-Archive go.zip -DestinationPath C:\; \
+{{ if install_directory != "C:\\go" then ( -}}
+	\
+	Write-Host 'Moving ...'; \
+	Move-Item -Path C:\go -Destination '{{ install_directory }}'; \
+{{ ) else "" end -}}
 	\
 	Write-Host 'Removing ...'; \
 	Remove-Item go.zip -Force; \

--- a/apply-templates.sh
+++ b/apply-templates.sh
@@ -7,7 +7,7 @@ jqt='.jq-template.awk'
 if [ -n "${BASHBREW_SCRIPTS:-}" ]; then
 	jqt="$BASHBREW_SCRIPTS/jq-template.awk"
 elif [ "$BASH_SOURCE" -nt "$jqt" ]; then
-	wget -qO "$jqt" 'https://github.com/docker-library/bashbrew/raw/5f0c26381fb7cc78b2d217d58007800bdcfbcfa1/scripts/jq-template.awk'
+	wget -qO "$jqt" 'https://github.com/docker-library/bashbrew/raw/1da7341a79651d28fbcc3d14b9176593c4231942/scripts/jq-template.awk'
 fi
 
 if [ "$#" -eq 0 ]; then


### PR DESCRIPTION
This matches Go upstream's change to the same, and allows GOPATH on 1.17+ to move to C:\go (although with the caveat that GOPATH may not actually be useful for much longer).

See https://golang.org/cl/283600 for where this was changed in the official Go installer.

See also:

- https://github.com/golang/go/issues/23848
- https://github.com/golang/go/issues/42070