### PR TITLE
Enable TLS 1.2 for Go download on Windows

### DIFF
--- a/1.16/windows/windowsservercore-1809/Dockerfile
+++ b/1.16/windows/windowsservercore-1809/Dockerfile
@@ -57,6 +57,7 @@ ENV GOLANG_VERSION 1.16.7
 
 RUN $url = 'https://dl.google.com/go/go1.16.7.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
 	$sha256 = '56b3a9024268f226f679c3a8ffb21f4214a75f84050b2c395b362ae2cc8e53e9'; \

--- a/1.16/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/1.16/windows/windowsservercore-ltsc2016/Dockerfile
@@ -57,6 +57,7 @@ ENV GOLANG_VERSION 1.16.7
 
 RUN $url = 'https://dl.google.com/go/go1.16.7.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
 	$sha256 = '56b3a9024268f226f679c3a8ffb21f4214a75f84050b2c395b362ae2cc8e53e9'; \

--- a/1.16/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/1.16/windows/windowsservercore-ltsc2022/Dockerfile
@@ -57,6 +57,7 @@ ENV GOLANG_VERSION 1.16.7
 
 RUN $url = 'https://dl.google.com/go/go1.16.7.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
 	$sha256 = '56b3a9024268f226f679c3a8ffb21f4214a75f84050b2c395b362ae2cc8e53e9'; \

--- a/1.17/windows/windowsservercore-1809/Dockerfile
+++ b/1.17/windows/windowsservercore-1809/Dockerfile
@@ -57,6 +57,7 @@ ENV GOLANG_VERSION 1.17
 
 RUN $url = 'https://dl.google.com/go/go1.17.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
 	$sha256 = '2a18bd65583e221be8b9b7c2fbe3696c40f6e27c2df689bbdcc939d49651d151'; \

--- a/1.17/windows/windowsservercore-ltsc2016/Dockerfile
+++ b/1.17/windows/windowsservercore-ltsc2016/Dockerfile
@@ -57,6 +57,7 @@ ENV GOLANG_VERSION 1.17
 
 RUN $url = 'https://dl.google.com/go/go1.17.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
 	$sha256 = '2a18bd65583e221be8b9b7c2fbe3696c40f6e27c2df689bbdcc939d49651d151'; \

--- a/1.17/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/1.17/windows/windowsservercore-ltsc2022/Dockerfile
@@ -57,6 +57,7 @@ ENV GOLANG_VERSION 1.17
 
 RUN $url = 'https://dl.google.com/go/go1.17.windows-amd64.zip'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
 	$sha256 = '2a18bd65583e221be8b9b7c2fbe3696c40f6e27c2df689bbdcc939d49651d151'; \

--- a/Dockerfile-windows-servercore.template
+++ b/Dockerfile-windows-servercore.template
@@ -65,6 +65,7 @@ ENV GOLANG_VERSION {{ .version }}
 
 RUN $url = '{{ .arches["windows-amd64"].url }}'; \
 	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
 	\
 	$sha256 = '{{ .arches["windows-amd64"].sha256 }}'; \


### PR DESCRIPTION
Resolves https://github.com/docker-library/golang/issues/388