### PR TITLE
Remove unnecessary "go install std"

### DIFF
--- a/1.16/alpine3.14/Dockerfile
+++ b/1.16/alpine3.14/Dockerfile
@@ -88,11 +88,6 @@ RUN set -eux; \
 		\
 		apk del --no-network .build-deps; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.16/alpine3.15/Dockerfile
+++ b/1.16/alpine3.15/Dockerfile
@@ -88,11 +88,6 @@ RUN set -eux; \
 		\
 		apk del --no-network .build-deps; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.16/bullseye/Dockerfile
+++ b/1.16/bullseye/Dockerfile
@@ -103,11 +103,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.16/buster/Dockerfile
+++ b/1.16/buster/Dockerfile
@@ -103,11 +103,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.16/stretch/Dockerfile
+++ b/1.16/stretch/Dockerfile
@@ -103,11 +103,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.17/alpine3.14/Dockerfile
+++ b/1.17/alpine3.14/Dockerfile
@@ -88,11 +88,6 @@ RUN set -eux; \
 		\
 		apk del --no-network .build-deps; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.17/alpine3.15/Dockerfile
+++ b/1.17/alpine3.15/Dockerfile
@@ -88,11 +88,6 @@ RUN set -eux; \
 		\
 		apk del --no-network .build-deps; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.17/bullseye/Dockerfile
+++ b/1.17/bullseye/Dockerfile
@@ -103,11 +103,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.17/buster/Dockerfile
+++ b/1.17/buster/Dockerfile
@@ -103,11 +103,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.17/stretch/Dockerfile
+++ b/1.17/stretch/Dockerfile
@@ -103,11 +103,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.18-rc/alpine3.14/Dockerfile
+++ b/1.18-rc/alpine3.14/Dockerfile
@@ -88,11 +88,6 @@ RUN set -eux; \
 		\
 		apk del --no-network .build-deps; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.18-rc/alpine3.15/Dockerfile
+++ b/1.18-rc/alpine3.15/Dockerfile
@@ -88,11 +88,6 @@ RUN set -eux; \
 		\
 		apk del --no-network .build-deps; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.18-rc/bullseye/Dockerfile
+++ b/1.18-rc/bullseye/Dockerfile
@@ -103,11 +103,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.18-rc/buster/Dockerfile
+++ b/1.18-rc/buster/Dockerfile
@@ -103,11 +103,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/1.18-rc/stretch/Dockerfile
+++ b/1.18-rc/stretch/Dockerfile
@@ -103,11 +103,6 @@ RUN set -eux; \
 		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -156,11 +156,6 @@ RUN set -eux; \
 		rm -rf /var/lib/apt/lists/*; \
 {{ ) end -}}
 		\
-# pre-compile the standard library, just like the official binary release tarballs do
-		go install std; \
-# go install: -race is only supported on linux/amd64, linux/ppc64le, linux/arm64, freebsd/amd64, netbsd/amd64, darwin/amd64 and windows/amd64
-#		go install -race std; \
-		\
 # remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
 		rm -rf \
 			/usr/local/go/pkg/*/cmd \


### PR DESCRIPTION
Also, remove misleading comment about `go install -race std` - it's already there in the pre-built releases and we don't want to include it in Alpine.

Closes #407 (thanks @rittneje!)