### PR TITLE
Temporarily apply upstream patch for 1.18 + Alpine + ppc64le

### DIFF
--- a/1.18/alpine3.14/Dockerfile
+++ b/1.18/alpine3.14/Dockerfile
@@ -78,6 +78,14 @@ RUN set -eux; \
 			go \
 			musl-dev \
 		; \
+		if [ "$GOARCH" = 'ppc64le' ]; then \
+# https://github.com/golang/go/issues/51787
+			wget -O ppc64le-alpine.patch 'https://github.com/golang/go/commit/946167906ed8646c433c257b074a10e01f0a7dab.patch'; \
+			apk add --no-cache --virtual .build-patch patch; \
+			patch --strip=1 --input="$PWD/ppc64le-alpine.patch" --directory=/usr/local/go; \
+			apk del --no-network .build-patch; \
+			rm ppc64le-alpine.patch; \
+		fi; \
 		\
 		( \
 			cd /usr/local/go/src; \

--- a/1.18/alpine3.15/Dockerfile
+++ b/1.18/alpine3.15/Dockerfile
@@ -78,6 +78,14 @@ RUN set -eux; \
 			go \
 			musl-dev \
 		; \
+		if [ "$GOARCH" = 'ppc64le' ]; then \
+# https://github.com/golang/go/issues/51787
+			wget -O ppc64le-alpine.patch 'https://github.com/golang/go/commit/946167906ed8646c433c257b074a10e01f0a7dab.patch'; \
+			apk add --no-cache --virtual .build-patch patch; \
+			patch --strip=1 --input="$PWD/ppc64le-alpine.patch" --directory=/usr/local/go; \
+			apk del --no-network .build-patch; \
+			rm ppc64le-alpine.patch; \
+		fi; \
 		\
 		( \
 			cd /usr/local/go/src; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -134,6 +134,16 @@ RUN set -eux; \
 			go \
 			musl-dev \
 		; \
+{{ if env.version == "1.18" then ( -}}
+		if [ "$GOARCH" = 'ppc64le' ]; then \
+# https://github.com/golang/go/issues/51787
+			wget -O ppc64le-alpine.patch 'https://github.com/golang/go/commit/946167906ed8646c433c257b074a10e01f0a7dab.patch'; \
+			apk add --no-cache --virtual .build-patch patch; \
+			patch --strip=1 --input="$PWD/ppc64le-alpine.patch" --directory=/usr/local/go; \
+			apk del --no-network .build-patch; \
+			rm ppc64le-alpine.patch; \
+		fi; \
+{{ ) else "" end -}}
 {{ ) else ( -}}
 		savedAptMark="$(apt-mark showmanual)"; \
 		apt-get update; \


### PR DESCRIPTION
Closes https://github.com/docker-library/golang/issues/416

This applies the upstream patch from @pmur (thank you for doing that! :heart:) -- there's a backport happening in https://github.com/golang/go/issues/51874, so hopefully we can remove this hack for 1.18.1, but given the commit is accepted upstream and I've verified that it works and fixes the issue, it seems to me like it's pretty reasonable for us to apply it now (since I'm not sure when 1.18.1 might come and the patch is so small).