### PR TITLE
Revert upstream-applied ppc64le patch

### DIFF
--- a/1.18/alpine3.14/Dockerfile
+++ b/1.18/alpine3.14/Dockerfile
@@ -78,14 +78,6 @@ RUN set -eux; \
 			go \
 			musl-dev \
 		; \
-		if [ "$GOARCH" = 'ppc64le' ]; then \
-# https://github.com/golang/go/issues/51787
-			wget -O ppc64le-alpine.patch 'https://github.com/golang/go/commit/946167906ed8646c433c257b074a10e01f0a7dab.patch'; \
-			apk add --no-cache --virtual .build-patch patch; \
-			patch --strip=1 --input="$PWD/ppc64le-alpine.patch" --directory=/usr/local/go; \
-			apk del --no-network .build-patch; \
-			rm ppc64le-alpine.patch; \
-		fi; \
 		\
 		( \
 			cd /usr/local/go/src; \

--- a/1.18/alpine3.15/Dockerfile
+++ b/1.18/alpine3.15/Dockerfile
@@ -78,14 +78,6 @@ RUN set -eux; \
 			go \
 			musl-dev \
 		; \
-		if [ "$GOARCH" = 'ppc64le' ]; then \
-# https://github.com/golang/go/issues/51787
-			wget -O ppc64le-alpine.patch 'https://github.com/golang/go/commit/946167906ed8646c433c257b074a10e01f0a7dab.patch'; \
-			apk add --no-cache --virtual .build-patch patch; \
-			patch --strip=1 --input="$PWD/ppc64le-alpine.patch" --directory=/usr/local/go; \
-			apk del --no-network .build-patch; \
-			rm ppc64le-alpine.patch; \
-		fi; \
 		\
 		( \
 			cd /usr/local/go/src; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -134,16 +134,6 @@ RUN set -eux; \
 			go \
 			musl-dev \
 		; \
-{{ if env.version == "1.18" then ( -}}
-		if [ "$GOARCH" = 'ppc64le' ]; then \
-# https://github.com/golang/go/issues/51787
-			wget -O ppc64le-alpine.patch 'https://github.com/golang/go/commit/946167906ed8646c433c257b074a10e01f0a7dab.patch'; \
-			apk add --no-cache --virtual .build-patch patch; \
-			patch --strip=1 --input="$PWD/ppc64le-alpine.patch" --directory=/usr/local/go; \
-			apk del --no-network .build-patch; \
-			rm ppc64le-alpine.patch; \
-		fi; \
-{{ ) else "" end -}}
 {{ ) else ( -}}
 		savedAptMark="$(apt-mark showmanual)"; \
 		apt-get update; \


### PR DESCRIPTION
The build for ppc64le [fails currently](https://doi-janky.infosiftr.net/job/multiarch/view/images/view/golang/job/ppc64le/job/golang/), due to [not being able to apply the patch](https://doi-janky.infosiftr.net/job/multiarch/view/images/view/golang/job/ppc64le/job/golang/601/execution/node/101/log/) from #417 for #416, as it is already part of Go 1.18.1:
* https://github.com/golang/go/issues/51874
* https://github.com/golang/go/commit/0bf8319883298dbeea81444cb704d8c0e9935bae

Reverts #417