### PR TITLE
Set GOAMD64 explicitly to v1

### DIFF
--- a/1.18/alpine3.14/Dockerfile
+++ b/1.18/alpine3.14/Dockerfile
@@ -23,7 +23,7 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			export GOARCH='amd64' GOOS='linux'; \
+			export GOAMD64='v1' GOARCH='amd64' GOOS='linux'; \
 			;; \
 		'armhf') \
 			export GOARCH='arm' GOARM='6' GOOS='linux'; \

--- a/1.18/alpine3.15/Dockerfile
+++ b/1.18/alpine3.15/Dockerfile
@@ -23,7 +23,7 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			export GOARCH='amd64' GOOS='linux'; \
+			export GOAMD64='v1' GOARCH='amd64' GOOS='linux'; \
 			;; \
 		'armhf') \
 			export GOARCH='arm' GOARM='6' GOOS='linux'; \

--- a/versions.json
+++ b/versions.json
@@ -168,6 +168,7 @@
     "arches": {
       "amd64": {
         "env": {
+          "GOAMD64": "v1",
           "GOARCH": "amd64",
           "GOOS": "linux"
         },

--- a/versions.sh
+++ b/versions.sh
@@ -71,6 +71,9 @@ goVersions="$(
 									+ if .arch == "386" and .os == "linux" then
 										# i386 in Debian is non-SSE2, Alpine appears to be similar (but interesting, not FreeBSD?)
 										{ GO386: "softfloat" }
+									elif .arch == "amd64" and .os == "linux" and $major != "1.17" then
+										# https://tip.golang.org/doc/go1.18#amd64
+										{ GOAMD64: "v1" }
 									elif $bashbrewArch | startswith("arm32v") then
 										{ GOARCH: "arm", GOARM: ($bashbrewArch | ltrimstr("arm32v")) }
 									else {} end


### PR DESCRIPTION
This is already the default, but it seems like a good idea to be explicit about it.

(See also https://tip.golang.org/doc/go1.18#amd64)