### PR TITLE
Ensure nsswitch.conf config for netgo

### DIFF
--- a/1.18/alpine3.15/Dockerfile
+++ b/1.18/alpine3.15/Dockerfile
@@ -8,10 +8,16 @@ FROM alpine:3.15
 
 RUN apk add --no-cache ca-certificates
 
-# set up nsswitch.conf for Go's "netgo" implementation
-# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+# ensure that nsswitch.conf is set up for Go's "netgo" implementation
+# - https://github.com/golang/go/blob/go1.19.3/src/net/conf.go#L227-L303
 # - docker run --rm debian grep '^hosts:' /etc/nsswitch.conf
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+# Alpine 3.16 includes nsswitch.conf
+RUN set -eux; \
+	if [ -e /etc/nsswitch.conf ]; then \
+		grep '^hosts: files dns' /etc/nsswitch.conf; \
+	else \
+		echo 'hosts: files dns' > /etc/nsswitch.conf; \
+	fi
 
 ENV PATH /usr/local/go/bin:$PATH
 

--- a/1.18/alpine3.16/Dockerfile
+++ b/1.18/alpine3.16/Dockerfile
@@ -8,10 +8,16 @@ FROM alpine:3.16
 
 RUN apk add --no-cache ca-certificates
 
-# set up nsswitch.conf for Go's "netgo" implementation
-# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+# ensure that nsswitch.conf is set up for Go's "netgo" implementation
+# - https://github.com/golang/go/blob/go1.19.3/src/net/conf.go#L227-L303
 # - docker run --rm debian grep '^hosts:' /etc/nsswitch.conf
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+# Alpine 3.16 includes nsswitch.conf
+RUN set -eux; \
+	if [ -e /etc/nsswitch.conf ]; then \
+		grep '^hosts: files dns' /etc/nsswitch.conf; \
+	else \
+		echo 'hosts: files dns' > /etc/nsswitch.conf; \
+	fi
 
 ENV PATH /usr/local/go/bin:$PATH
 

--- a/1.19/alpine3.15/Dockerfile
+++ b/1.19/alpine3.15/Dockerfile
@@ -8,10 +8,16 @@ FROM alpine:3.15
 
 RUN apk add --no-cache ca-certificates
 
-# set up nsswitch.conf for Go's "netgo" implementation
-# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+# ensure that nsswitch.conf is set up for Go's "netgo" implementation
+# - https://github.com/golang/go/blob/go1.19.3/src/net/conf.go#L227-L303
 # - docker run --rm debian grep '^hosts:' /etc/nsswitch.conf
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+# Alpine 3.16 includes nsswitch.conf
+RUN set -eux; \
+	if [ -e /etc/nsswitch.conf ]; then \
+		grep '^hosts: files dns' /etc/nsswitch.conf; \
+	else \
+		echo 'hosts: files dns' > /etc/nsswitch.conf; \
+	fi
 
 ENV PATH /usr/local/go/bin:$PATH
 

--- a/1.19/alpine3.16/Dockerfile
+++ b/1.19/alpine3.16/Dockerfile
@@ -8,10 +8,16 @@ FROM alpine:3.16
 
 RUN apk add --no-cache ca-certificates
 
-# set up nsswitch.conf for Go's "netgo" implementation
-# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+# ensure that nsswitch.conf is set up for Go's "netgo" implementation
+# - https://github.com/golang/go/blob/go1.19.3/src/net/conf.go#L227-L303
 # - docker run --rm debian grep '^hosts:' /etc/nsswitch.conf
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+# Alpine 3.16 includes nsswitch.conf
+RUN set -eux; \
+	if [ -e /etc/nsswitch.conf ]; then \
+		grep '^hosts: files dns' /etc/nsswitch.conf; \
+	else \
+		echo 'hosts: files dns' > /etc/nsswitch.conf; \
+	fi
 
 ENV PATH /usr/local/go/bin:$PATH
 

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -10,10 +10,16 @@ FROM alpine:{{ alpine_version }}
 
 RUN apk add --no-cache ca-certificates
 
-# set up nsswitch.conf for Go's "netgo" implementation
-# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+# ensure that nsswitch.conf is set up for Go's "netgo" implementation
+# - https://github.com/golang/go/blob/go1.19.3/src/net/conf.go#L227-L303
 # - docker run --rm debian grep '^hosts:' /etc/nsswitch.conf
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+# Alpine 3.16 includes nsswitch.conf
+RUN set -eux; \
+	if [ -e /etc/nsswitch.conf ]; then \
+		grep '^hosts: files dns' /etc/nsswitch.conf; \
+	else \
+		echo 'hosts: files dns' > /etc/nsswitch.conf; \
+	fi
 {{ ) else ( -}}
 FROM buildpack-deps:{{ env.variant }}-scm
 


### PR DESCRIPTION
Alpine 3.16 has updated to [include an `nsswitch.conf`](https://git.alpinelinux.org/aports/commit/main/alpine-baselayout?h=3.16-stable&id=348653a9ba0701e8e968b3344e72313a9ef334e4). But we need to ensure 3.15 still works as well.

```console
Step 1/10 : FROM alpine:3.15
Step 3/10 : RUN set -eux; 	if [ -e /etc/nsswitch.conf ]; then 		grep '^hosts: files dns' /etc/nsswitch.conf; 	else 		echo 'hosts: files dns' > /etc/nsswitch.conf; 	fi
 ---> Running in 79d0f913ddf7
+ '[' -e /etc/nsswitch.conf ]
+ echo 'hosts: files dns'
```
```console
Step 1/10 : FROM alpine:3.16
...
Step 3/10 : RUN set -eux; 	if [ -e /etc/nsswitch.conf ]; then 		grep '^hosts: files dns' /etc/nsswitch.conf; 	else 		echo 'hosts: files dns' > /etc/nsswitch.conf; 	fi
 ---> Running in b9440f91dc03
+ '[' -e /etc/nsswitch.conf ]
+ grep '^hosts: files dns' /etc/nsswitch.conf
```

Related to https://github.com/docker-library/docker/pull/384