### PR TITLE
Add support for alpine 3.17, remove alpine 3.15

### DIFF
--- a/1.18/alpine3.16/Dockerfile
+++ b/1.18/alpine3.16/Dockerfile
@@ -8,17 +8,6 @@ FROM alpine:3.16
 
 RUN apk add --no-cache ca-certificates
 
-# ensure that nsswitch.conf is set up for Go's "netgo" implementation
-# - https://github.com/golang/go/blob/go1.19.3/src/net/conf.go#L227-L303
-# - docker run --rm debian grep '^hosts:' /etc/nsswitch.conf
-# Alpine 3.16 includes nsswitch.conf
-RUN set -eux; \
-	if [ -e /etc/nsswitch.conf ]; then \
-		grep '^hosts: files dns' /etc/nsswitch.conf; \
-	else \
-		echo 'hosts: files dns' > /etc/nsswitch.conf; \
-	fi
-
 ENV PATH /usr/local/go/bin:$PATH
 
 ENV GOLANG_VERSION 1.18.8

--- a/1.18/alpine3.17/Dockerfile
+++ b/1.18/alpine3.17/Dockerfile
@@ -4,24 +4,13 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.15
+FROM alpine:3.17
 
 RUN apk add --no-cache ca-certificates
 
-# ensure that nsswitch.conf is set up for Go's "netgo" implementation
-# - https://github.com/golang/go/blob/go1.19.3/src/net/conf.go#L227-L303
-# - docker run --rm debian grep '^hosts:' /etc/nsswitch.conf
-# Alpine 3.16 includes nsswitch.conf
-RUN set -eux; \
-	if [ -e /etc/nsswitch.conf ]; then \
-		grep '^hosts: files dns' /etc/nsswitch.conf; \
-	else \
-		echo 'hosts: files dns' > /etc/nsswitch.conf; \
-	fi
-
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.19.3
+ENV GOLANG_VERSION 1.18.8
 
 RUN set -eux; \
 	apk add --no-cache --virtual .fetch-deps gnupg; \
@@ -55,8 +44,8 @@ RUN set -eux; \
 	if [ -z "$url" ]; then \
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
 		build=1; \
-		url='https://dl.google.com/go/go1.19.3.src.tar.gz'; \
-		sha256='18ac263e39210bcf68d85f4370e97fb1734166995a1f63fb38b4f6e07d90d212'; \
+		url='https://dl.google.com/go/go1.18.8.src.tar.gz'; \
+		sha256='1f79802305015479e77d8c641530bc54ec994657d5c5271e0172eb7118346a12'; \
 # the precompiled binaries published by Go upstream are not compatible with Alpine, so we always build from source here 😅
 	fi; \
 	\
@@ -91,10 +80,6 @@ RUN set -eux; \
 			cd /usr/local/go/src; \
 # set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
 			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
-			if [ "${GOARCH:-}" = '386' ]; then \
-# https://github.com/golang/go/issues/52919; https://github.com/docker-library/golang/pull/426#issuecomment-1152623837
-				export CGO_CFLAGS='-fno-stack-protector'; \
-			fi; \
 			./make.bash; \
 		); \
 		\

--- a/1.19/alpine3.16/Dockerfile
+++ b/1.19/alpine3.16/Dockerfile
@@ -8,17 +8,6 @@ FROM alpine:3.16
 
 RUN apk add --no-cache ca-certificates
 
-# ensure that nsswitch.conf is set up for Go's "netgo" implementation
-# - https://github.com/golang/go/blob/go1.19.3/src/net/conf.go#L227-L303
-# - docker run --rm debian grep '^hosts:' /etc/nsswitch.conf
-# Alpine 3.16 includes nsswitch.conf
-RUN set -eux; \
-	if [ -e /etc/nsswitch.conf ]; then \
-		grep '^hosts: files dns' /etc/nsswitch.conf; \
-	else \
-		echo 'hosts: files dns' > /etc/nsswitch.conf; \
-	fi
-
 ENV PATH /usr/local/go/bin:$PATH
 
 ENV GOLANG_VERSION 1.19.3

--- a/1.19/alpine3.17/Dockerfile
+++ b/1.19/alpine3.17/Dockerfile
@@ -4,24 +4,13 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.15
+FROM alpine:3.17
 
 RUN apk add --no-cache ca-certificates
 
-# ensure that nsswitch.conf is set up for Go's "netgo" implementation
-# - https://github.com/golang/go/blob/go1.19.3/src/net/conf.go#L227-L303
-# - docker run --rm debian grep '^hosts:' /etc/nsswitch.conf
-# Alpine 3.16 includes nsswitch.conf
-RUN set -eux; \
-	if [ -e /etc/nsswitch.conf ]; then \
-		grep '^hosts: files dns' /etc/nsswitch.conf; \
-	else \
-		echo 'hosts: files dns' > /etc/nsswitch.conf; \
-	fi
-
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.18.8
+ENV GOLANG_VERSION 1.19.3
 
 RUN set -eux; \
 	apk add --no-cache --virtual .fetch-deps gnupg; \
@@ -55,8 +44,8 @@ RUN set -eux; \
 	if [ -z "$url" ]; then \
 # https://github.com/golang/go/issues/38536#issuecomment-616897960
 		build=1; \
-		url='https://dl.google.com/go/go1.18.8.src.tar.gz'; \
-		sha256='1f79802305015479e77d8c641530bc54ec994657d5c5271e0172eb7118346a12'; \
+		url='https://dl.google.com/go/go1.19.3.src.tar.gz'; \
+		sha256='18ac263e39210bcf68d85f4370e97fb1734166995a1f63fb38b4f6e07d90d212'; \
 # the precompiled binaries published by Go upstream are not compatible with Alpine, so we always build from source here 😅
 	fi; \
 	\
@@ -91,6 +80,10 @@ RUN set -eux; \
 			cd /usr/local/go/src; \
 # set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
 			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
+			if [ "${GOARCH:-}" = '386' ]; then \
+# https://github.com/golang/go/issues/52919; https://github.com/docker-library/golang/pull/426#issuecomment-1152623837
+				export CGO_CFLAGS='-fno-stack-protector'; \
+			fi; \
 			./make.bash; \
 		); \
 		\

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -9,17 +9,6 @@
 FROM alpine:{{ alpine_version }}
 
 RUN apk add --no-cache ca-certificates
-
-# ensure that nsswitch.conf is set up for Go's "netgo" implementation
-# - https://github.com/golang/go/blob/go1.19.3/src/net/conf.go#L227-L303
-# - docker run --rm debian grep '^hosts:' /etc/nsswitch.conf
-# Alpine 3.16 includes nsswitch.conf
-RUN set -eux; \
-	if [ -e /etc/nsswitch.conf ]; then \
-		grep '^hosts: files dns' /etc/nsswitch.conf; \
-	else \
-		echo 'hosts: files dns' > /etc/nsswitch.conf; \
-	fi
 {{ ) else ( -}}
 FROM buildpack-deps:{{ env.variant }}-scm
 

--- a/versions.json
+++ b/versions.json
@@ -155,8 +155,8 @@
     "variants": [
       "bullseye",
       "buster",
+      "alpine3.17",
       "alpine3.16",
-      "alpine3.15",
       "windows/windowsservercore-ltsc2022",
       "windows/windowsservercore-1809",
       "windows/nanoserver-ltsc2022",
@@ -320,8 +320,8 @@
     "variants": [
       "bullseye",
       "buster",
+      "alpine3.17",
       "alpine3.16",
-      "alpine3.15",
       "windows/windowsservercore-ltsc2022",
       "windows/windowsservercore-1809",
       "windows/nanoserver-ltsc2022",

--- a/versions.sh
+++ b/versions.sh
@@ -144,8 +144,8 @@ for version in "${versions[@]}"; do
 			"bullseye",
 			"buster",
 			(
-				"3.16",
-				"3.15"
+				"3.17",
+				"3.16"
 			| "alpine" + .),
 			if .arches | has("windows-amd64") then
 				(


### PR DESCRIPTION
This PR adds support for alpine 3.17 and removes support for 3.15 to adhere to the policy of only supporting two major releases.