### PR TITLE
Fix 1.20 builds on mips and arm32v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         name: Generate Jobs
         run: |
           strategy="$("$BASHBREW_SCRIPTS/github-actions/generate.sh")"
+          strategy="$(.github/workflows/munge.sh -c <<<"$strategy")"
           strategy="$("$BASHBREW_SCRIPTS/github-actions/munge-i386.sh" -c <<<"$strategy")"
           echo "strategy=$strategy" >> "$GITHUB_OUTPUT"
           jq . <<<"$strategy" # sanity check / debugging aid

--- a/.github/workflows/munge.sh
+++ b/.github/workflows/munge.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# we use this to munge "versions.json" to force building on all arches
+versionsMunge='.[].arches |= with_entries(if .key != "src" then del(.value.url, .value.sha256) else . end)'
+export versionsMunge
+
+jq '
+	.matrix.include += [
+		.matrix.include[]
+		| select(.name | test(" (.+)") | not) # ignore any existing munged builds
+		| select(.os | startswith("windows-") | not) # ignore Windows (always downloads)
+		| select(.meta.froms[] | test("^alpine:") | not) # ignore Alpine (already always builds from source)
+		| select(.meta.froms[] | test("buster") | not) # ignore Debian Buster (not new enough Go, only supports architectures that download)
+		| .name += " (force build)"
+		| .runs.build = ([
+			"# update versions.json to force us to build Go instead of downloading it",
+			"jq " + (env.versionsMunge | @sh) + " versions.json | tee versions.munged.json",
+			"mv versions.munged.json versions.json",
+			"./apply-templates.sh",
+			"git diff",
+			.runs.build
+		] | join("\n"))
+	]
+' "$@"

--- a/1.20-rc/bullseye/Dockerfile
+++ b/1.20-rc/bullseye/Dockerfile
@@ -88,8 +88,14 @@ RUN set -eux; \
 	\
 	if [ -n "$build" ]; then \
 		savedAptMark="$(apt-mark showmanual)"; \
-		apt-get update; \
-		apt-get install -y --no-install-recommends golang-go; \
+# add backports for newer go version for bootstrap build: https://github.com/golang/go/issues/44505
+		( \
+			. /etc/os-release; \
+			echo "deb https://deb.debian.org/debian $VERSION_CODENAME-backports main" > /etc/apt/sources.list.d/backports.list; \
+			\
+			apt-get update; \
+			apt-get install -y --no-install-recommends -t "$VERSION_CODENAME-backports" golang-go; \
+		); \
 		\
 		export GOCACHE='/tmp/gocache'; \
 		\

--- a/1.20-rc/buster/Dockerfile
+++ b/1.20-rc/buster/Dockerfile
@@ -88,8 +88,14 @@ RUN set -eux; \
 	\
 	if [ -n "$build" ]; then \
 		savedAptMark="$(apt-mark showmanual)"; \
-		apt-get update; \
-		apt-get install -y --no-install-recommends golang-go; \
+# add backports for newer go version for bootstrap build: https://github.com/golang/go/issues/44505
+		( \
+			. /etc/os-release; \
+			echo "deb https://deb.debian.org/debian $VERSION_CODENAME-backports main" > /etc/apt/sources.list.d/backports.list; \
+			\
+			apt-get update; \
+			apt-get install -y --no-install-recommends -t "$VERSION_CODENAME-backports" golang-go; \
+		); \
 		\
 		export GOCACHE='/tmp/gocache'; \
 		\

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -131,8 +131,19 @@ RUN set -eux; \
 		; \
 {{ ) else ( -}}
 		savedAptMark="$(apt-mark showmanual)"; \
+{{ if [ "1.18", "1.19" ] | index(env.version) then ( -}}
 		apt-get update; \
 		apt-get install -y --no-install-recommends golang-go; \
+{{ ) else ( -}}
+# add backports for newer go version for bootstrap build: https://github.com/golang/go/issues/44505
+		( \
+			. /etc/os-release; \
+			echo "deb https://deb.debian.org/debian $VERSION_CODENAME-backports main" > /etc/apt/sources.list.d/backports.list; \
+			\
+			apt-get update; \
+			apt-get install -y --no-install-recommends -t "$VERSION_CODENAME-backports" golang-go; \
+		); \
+{{ ) end -}}
 {{ ) end -}}
 		\
 		export GOCACHE='/tmp/gocache'; \


### PR DESCRIPTION
> packages main (build.go) and building_Go_requires_Go_1_17_13_or_later (notgo117.go)

Also, update GitHub Actions to test force building on Debian so we can avoid this problem in the future.