### PR TITLE
Add debian:bookworm distro for 1.20 and 1.19

### DIFF
--- a/1.19/bookworm/Dockerfile
+++ b/1.19/bookworm/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:buster-scm
+FROM buildpack-deps:bookworm-scm
 
 # install cgo-related dependencies
 RUN set -eux; \

--- a/1.20/bookworm/Dockerfile
+++ b/1.20/bookworm/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:buster-scm
+FROM buildpack-deps:bookworm-scm
 
 # install cgo-related dependencies
 RUN set -eux; \
@@ -88,14 +88,8 @@ RUN set -eux; \
 	\
 	if [ -n "$build" ]; then \
 		savedAptMark="$(apt-mark showmanual)"; \
-# add backports for newer go version for bootstrap build: https://github.com/golang/go/issues/44505
-		( \
-			. /etc/os-release; \
-			echo "deb https://deb.debian.org/debian $VERSION_CODENAME-backports main" > /etc/apt/sources.list.d/backports.list; \
-			\
-			apt-get update; \
-			apt-get install -y --no-install-recommends -t "$VERSION_CODENAME-backports" golang-go; \
-		); \
+		apt-get update; \
+		apt-get install -y --no-install-recommends golang-go; \
 		\
 		export GOCACHE='/tmp/gocache'; \
 		\

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -131,7 +131,7 @@ RUN set -eux; \
 		; \
 {{ ) else ( -}}
 		savedAptMark="$(apt-mark showmanual)"; \
-{{ if [ "1.19" ] | index(env.version) then ( -}}
+{{ if [ "1.19" ] | index(env.version) or env.variant != "bullseye" then ( -}}
 		apt-get update; \
 		apt-get install -y --no-install-recommends golang-go; \
 {{ ) else ( -}}

--- a/versions.json
+++ b/versions.json
@@ -153,8 +153,8 @@
       }
     },
     "variants": [
+      "bookworm",
       "bullseye",
-      "buster",
       "alpine3.18",
       "alpine3.17",
       "windows/windowsservercore-ltsc2022",
@@ -318,8 +318,8 @@
       }
     },
     "variants": [
+      "bookworm",
       "bullseye",
-      "buster",
       "alpine3.18",
       "alpine3.17",
       "windows/windowsservercore-ltsc2022",

--- a/versions.sh
+++ b/versions.sh
@@ -143,8 +143,8 @@ for version in "${versions[@]}"; do
 		version: .version,
 		arches: .arches,
 		variants: [
+			"bookworm",
 			"bullseye",
-			"buster",
 			(
 				"3.18",
 				"3.17"


### PR DESCRIPTION
There are many CVEs not-fixed in bullseye that we need a newer version that is better with critical and high issues.