### PR TITLE
add debian-stable

### DIFF
--- a/1.20/debian-stable/Dockerfile
+++ b/1.20/debian-stable/Dockerfile
@@ -1,0 +1,128 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM buildpack-deps:stable-scm
+
+# install cgo-related dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		g++ \
+		gcc \
+		libc6-dev \
+		make \
+		pkg-config \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+ENV PATH /usr/local/go/bin:$PATH
+
+ENV GOLANG_VERSION 1.20.7
+
+RUN set -eux; \
+	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
+	url=; \
+	case "$arch" in \
+		'amd64') \
+			url='https://dl.google.com/go/go1.20.7.linux-amd64.tar.gz'; \
+			sha256='f0a87f1bcae91c4b69f8dc2bc6d7e6bfcd7524fceec130af525058c0c17b1b44'; \
+			;; \
+		'armel') \
+			export GOARCH='arm' GOARM='5' GOOS='linux'; \
+			;; \
+		'armhf') \
+			url='https://dl.google.com/go/go1.20.7.linux-armv6l.tar.gz'; \
+			sha256='7cc231b415b94f2f7065870a73f67dd2b0ec12b5a98052b7ee0121c42bc04f8d'; \
+			;; \
+		'arm64') \
+			url='https://dl.google.com/go/go1.20.7.linux-arm64.tar.gz'; \
+			sha256='44781ae3b153c3b07651d93b6bc554e835a36e2d72a696281c1e4dad9efffe43'; \
+			;; \
+		'i386') \
+			url='https://dl.google.com/go/go1.20.7.linux-386.tar.gz'; \
+			sha256='ddb48145f05bda2f4617a22c979d4e94b22802cdb1a1fde1b1974e733b26f091'; \
+			;; \
+		'mips64el') \
+			export GOARCH='mips64le' GOOS='linux'; \
+			;; \
+		'ppc64el') \
+			url='https://dl.google.com/go/go1.20.7.linux-ppc64le.tar.gz'; \
+			sha256='6318a1db307c12b8afe68808bd6fae4fba1e558a85b958216096869ed506dcb3'; \
+			;; \
+		'riscv64') \
+			export GOARCH='riscv64' GOOS='linux'; \
+			;; \
+		's390x') \
+			url='https://dl.google.com/go/go1.20.7.linux-s390x.tar.gz'; \
+			sha256='26aea2ede8722ceecbd9db883328a8d963136fd96c11dacc356c44c4c19c6515'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
+	esac; \
+	build=; \
+	if [ -z "$url" ]; then \
+# https://github.com/golang/go/issues/38536#issuecomment-616897960
+		build=1; \
+		url='https://dl.google.com/go/go1.20.7.src.tar.gz'; \
+		sha256='2c5ee9c9ec1e733b0dbbc2bdfed3f62306e51d8172bf38f4f4e542b27520f597'; \
+		echo >&2; \
+		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
+		echo >&2; \
+	fi; \
+	\
+	wget -O go.tgz.asc "$url.asc"; \
+	wget -O go.tgz "$url" --progress=dot:giga; \
+	echo "$sha256 *go.tgz" | sha256sum -c -; \
+	\
+# https://github.com/golang/go/issues/14739#issuecomment-324767697
+	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+# https://www.google.com/linuxrepositories/
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
+# let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys '2F52 8D36 D67B 69ED F998  D857 78BD 6547 3CB3 BD13'; \
+	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" go.tgz.asc; \
+	\
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+	if [ -n "$build" ]; then \
+		savedAptMark="$(apt-mark showmanual)"; \
+		apt-get update; \
+		apt-get install -y --no-install-recommends golang-go; \
+		\
+		export GOCACHE='/tmp/gocache'; \
+		\
+		( \
+			cd /usr/local/go/src; \
+# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
+			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
+			./make.bash; \
+		); \
+		\
+		apt-mark auto '.*' > /dev/null; \
+		apt-mark manual $savedAptMark > /dev/null; \
+		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+		rm -rf /var/lib/apt/lists/*; \
+		\
+# remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
+		rm -rf \
+			/usr/local/go/pkg/*/cmd \
+			/usr/local/go/pkg/bootstrap \
+			/usr/local/go/pkg/obj \
+			/usr/local/go/pkg/tool/*/api \
+			/usr/local/go/pkg/tool/*/go_bootstrap \
+			/usr/local/go/src/cmd/dist/dist \
+			"$GOCACHE" \
+		; \
+	fi; \
+	\
+	go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
+WORKDIR $GOPATH

--- a/1.21/debian-stable/Dockerfile
+++ b/1.21/debian-stable/Dockerfile
@@ -1,0 +1,130 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM buildpack-deps:stable-scm
+
+# install cgo-related dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		g++ \
+		gcc \
+		libc6-dev \
+		make \
+		pkg-config \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+ENV PATH /usr/local/go/bin:$PATH
+
+ENV GOLANG_VERSION 1.21.0
+
+RUN set -eux; \
+	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
+	url=; \
+	case "$arch" in \
+		'amd64') \
+			url='https://dl.google.com/go/go1.21.0.linux-amd64.tar.gz'; \
+			sha256='d0398903a16ba2232b389fb31032ddf57cac34efda306a0eebac34f0965a0742'; \
+			;; \
+		'armel') \
+			export GOARCH='arm' GOARM='5' GOOS='linux'; \
+			;; \
+		'armhf') \
+			url='https://dl.google.com/go/go1.21.0.linux-armv6l.tar.gz'; \
+			sha256='e377a0004957c8c560a3ff99601bce612330a3d95ba3b0a2ae144165fc87deb1'; \
+			;; \
+		'arm64') \
+			url='https://dl.google.com/go/go1.21.0.linux-arm64.tar.gz'; \
+			sha256='f3d4548edf9b22f26bbd49720350bbfe59d75b7090a1a2bff1afad8214febaf3'; \
+			;; \
+		'i386') \
+			url='https://dl.google.com/go/go1.21.0.linux-386.tar.gz'; \
+			sha256='0e6f378d9b072fab0a3d9ff4d5e990d98487d47252dba8160015a61e6bd0bcba'; \
+			;; \
+		'mips64el') \
+			url='https://dl.google.com/go/go1.21.0.linux-mips64le.tar.gz'; \
+			sha256='92f7933d997c589b4f506c6b3cc5b27ff43b294c3a2d40bf4d7eeaf375f92afb'; \
+			;; \
+		'ppc64el') \
+			url='https://dl.google.com/go/go1.21.0.linux-ppc64le.tar.gz'; \
+			sha256='e938ffc81d8ebe5efc179240960ba22da6a841ff05d5cab7ce2547112b14a47f'; \
+			;; \
+		'riscv64') \
+			url='https://dl.google.com/go/go1.21.0.linux-riscv64.tar.gz'; \
+			sha256='87b21c06573617842ca9e00b954bc9f534066736a0778eae594ac54b45a9e8b7'; \
+			;; \
+		's390x') \
+			url='https://dl.google.com/go/go1.21.0.linux-s390x.tar.gz'; \
+			sha256='be7338df8e5d5472dfa307b0df2b446d85d001b0a2a3cdb1a14048d751b70481'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
+	esac; \
+	build=; \
+	if [ -z "$url" ]; then \
+# https://github.com/golang/go/issues/38536#issuecomment-616897960
+		build=1; \
+		url='https://dl.google.com/go/go1.21.0.src.tar.gz'; \
+		sha256='818d46ede85682dd551ad378ef37a4d247006f12ec59b5b755601d2ce114369a'; \
+		echo >&2; \
+		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
+		echo >&2; \
+	fi; \
+	\
+	wget -O go.tgz.asc "$url.asc"; \
+	wget -O go.tgz "$url" --progress=dot:giga; \
+	echo "$sha256 *go.tgz" | sha256sum -c -; \
+	\
+# https://github.com/golang/go/issues/14739#issuecomment-324767697
+	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+# https://www.google.com/linuxrepositories/
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
+# let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys '2F52 8D36 D67B 69ED F998  D857 78BD 6547 3CB3 BD13'; \
+	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" go.tgz.asc; \
+	\
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+	if [ -n "$build" ]; then \
+		savedAptMark="$(apt-mark showmanual)"; \
+		apt-get update; \
+		apt-get install -y --no-install-recommends golang-go; \
+		\
+		export GOCACHE='/tmp/gocache'; \
+		\
+		( \
+			cd /usr/local/go/src; \
+# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
+			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
+			./make.bash; \
+		); \
+		\
+		apt-mark auto '.*' > /dev/null; \
+		apt-mark manual $savedAptMark > /dev/null; \
+		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+		rm -rf /var/lib/apt/lists/*; \
+		\
+# remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
+		rm -rf \
+			/usr/local/go/pkg/*/cmd \
+			/usr/local/go/pkg/bootstrap \
+			/usr/local/go/pkg/obj \
+			/usr/local/go/pkg/tool/*/api \
+			/usr/local/go/pkg/tool/*/go_bootstrap \
+			/usr/local/go/src/cmd/dist/dist \
+			"$GOCACHE" \
+		; \
+	fi; \
+	\
+	go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
+WORKDIR $GOPATH

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -8,13 +8,23 @@
 	def always_build_from_source:
 		# https://github.com/golang/go/issues/57007! (as of Go 1.21, the upstream release binaries are fully static and thus appropriate for Alpine)
 		is_alpine and ([ "1.20" ] | index(env.version | rtrimstr("-rc")))
+	;
+	def is_debian_but_not_one_to_one:
+		env.variant | startswith("debian")
+	;
+	def get_debian_channel:
+		env.variant | ltrimstr("debian-")
 -}}
 {{ if is_alpine then ( -}}
 FROM alpine:{{ alpine_version }}
 
 RUN apk add --no-cache ca-certificates
 {{ ) else ( -}}
+{{ if is_debian_but_not_one_to_one then ( -}}
+FROM buildpack-deps:{{ get_debian_channel }}-scm
+{{ ) else ( -}}
 FROM buildpack-deps:{{ env.variant }}-scm
+{{ ) end -}}
 
 # install cgo-related dependencies
 RUN set -eux; \

--- a/versions.json
+++ b/versions.json
@@ -162,6 +162,7 @@
     "variants": [
       "bookworm",
       "bullseye",
+      "debian-stable",
       "alpine3.18",
       "alpine3.17",
       "windows/windowsservercore-ltsc2022",
@@ -554,6 +555,7 @@
     "variants": [
       "bookworm",
       "bullseye",
+      "debian-stable",
       "alpine3.18",
       "alpine3.17",
       "windows/windowsservercore-ltsc2022",

--- a/versions.sh
+++ b/versions.sh
@@ -147,6 +147,7 @@ for version in "${versions[@]}"; do
 		variants: [
 			"bookworm",
 			"bullseye",
+			"debian-stable",
 			(
 				"3.18",
 				"3.17"


### PR DESCRIPTION
Based on:
https://github.com/debuerreotype/docker-debian-artifacts/issues/205#issuecomment-1684296039 I have based the `*debian-stable` not on an alias but on a different debian channel.

Fixes #485