### PR TITLE
Add back 1.19 temporarily for 1.19.13

### DIFF
--- a/1.19/alpine3.17/Dockerfile
+++ b/1.19/alpine3.17/Dockerfile
@@ -1,0 +1,114 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM alpine:3.17
+
+RUN apk add --no-cache ca-certificates
+
+ENV PATH /usr/local/go/bin:$PATH
+
+ENV GOLANG_VERSION 1.19.13
+
+RUN set -eux; \
+	apk add --no-cache --virtual .fetch-deps gnupg; \
+	arch="$(apk --print-arch)"; \
+	url=; \
+	case "$arch" in \
+		'x86_64') \
+			export GOAMD64='v1' GOARCH='amd64' GOOS='linux'; \
+			;; \
+		'armhf') \
+			export GOARCH='arm' GOARM='6' GOOS='linux'; \
+			;; \
+		'armv7') \
+			export GOARCH='arm' GOARM='7' GOOS='linux'; \
+			;; \
+		'aarch64') \
+			export GOARCH='arm64' GOOS='linux'; \
+			;; \
+		'x86') \
+			export GO386='softfloat' GOARCH='386' GOOS='linux'; \
+			;; \
+		'ppc64le') \
+			export GOARCH='ppc64le' GOOS='linux'; \
+			;; \
+		'riscv64') \
+			export GOARCH='riscv64' GOOS='linux'; \
+			;; \
+		's390x') \
+			export GOARCH='s390x' GOOS='linux'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
+	esac; \
+	build=; \
+	if [ -z "$url" ]; then \
+# https://github.com/golang/go/issues/38536#issuecomment-616897960
+		build=1; \
+		url='https://dl.google.com/go/go1.19.13.src.tar.gz'; \
+		sha256='ccf36b53fb0024a017353c3ddb22c1f00bc7a8073c6aac79042da24ee34434d3'; \
+# the precompiled binaries published by Go upstream are not compatible with Alpine, so we always build from source here 😅
+	fi; \
+	\
+	wget -O go.tgz.asc "$url.asc"; \
+	wget -O go.tgz "$url"; \
+	echo "$sha256 *go.tgz" | sha256sum -c -; \
+	\
+# https://github.com/golang/go/issues/14739#issuecomment-324767697
+	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+# https://www.google.com/linuxrepositories/
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
+# let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys '2F52 8D36 D67B 69ED F998  D857 78BD 6547 3CB3 BD13'; \
+	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" go.tgz.asc; \
+	\
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+	if [ -n "$build" ]; then \
+		apk add --no-cache --virtual .build-deps \
+			bash \
+			gcc \
+			go \
+			musl-dev \
+		; \
+		\
+		export GOCACHE='/tmp/gocache'; \
+		\
+		( \
+			cd /usr/local/go/src; \
+# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
+			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
+			if [ "${GOARCH:-}" = '386' ]; then \
+# https://github.com/golang/go/issues/52919; https://github.com/docker-library/golang/pull/426#issuecomment-1152623837
+				export CGO_CFLAGS='-fno-stack-protector'; \
+			fi; \
+			./make.bash; \
+		); \
+		\
+		apk del --no-network .build-deps; \
+		\
+# remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
+		rm -rf \
+			/usr/local/go/pkg/*/cmd \
+			/usr/local/go/pkg/bootstrap \
+			/usr/local/go/pkg/obj \
+			/usr/local/go/pkg/tool/*/api \
+			/usr/local/go/pkg/tool/*/go_bootstrap \
+			/usr/local/go/src/cmd/dist/dist \
+			"$GOCACHE" \
+		; \
+	fi; \
+	\
+	apk del --no-network .fetch-deps; \
+	\
+	go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
+WORKDIR $GOPATH

--- a/1.19/alpine3.18/Dockerfile
+++ b/1.19/alpine3.18/Dockerfile
@@ -1,0 +1,114 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM alpine:3.18
+
+RUN apk add --no-cache ca-certificates
+
+ENV PATH /usr/local/go/bin:$PATH
+
+ENV GOLANG_VERSION 1.19.13
+
+RUN set -eux; \
+	apk add --no-cache --virtual .fetch-deps gnupg; \
+	arch="$(apk --print-arch)"; \
+	url=; \
+	case "$arch" in \
+		'x86_64') \
+			export GOAMD64='v1' GOARCH='amd64' GOOS='linux'; \
+			;; \
+		'armhf') \
+			export GOARCH='arm' GOARM='6' GOOS='linux'; \
+			;; \
+		'armv7') \
+			export GOARCH='arm' GOARM='7' GOOS='linux'; \
+			;; \
+		'aarch64') \
+			export GOARCH='arm64' GOOS='linux'; \
+			;; \
+		'x86') \
+			export GO386='softfloat' GOARCH='386' GOOS='linux'; \
+			;; \
+		'ppc64le') \
+			export GOARCH='ppc64le' GOOS='linux'; \
+			;; \
+		'riscv64') \
+			export GOARCH='riscv64' GOOS='linux'; \
+			;; \
+		's390x') \
+			export GOARCH='s390x' GOOS='linux'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
+	esac; \
+	build=; \
+	if [ -z "$url" ]; then \
+# https://github.com/golang/go/issues/38536#issuecomment-616897960
+		build=1; \
+		url='https://dl.google.com/go/go1.19.13.src.tar.gz'; \
+		sha256='ccf36b53fb0024a017353c3ddb22c1f00bc7a8073c6aac79042da24ee34434d3'; \
+# the precompiled binaries published by Go upstream are not compatible with Alpine, so we always build from source here 😅
+	fi; \
+	\
+	wget -O go.tgz.asc "$url.asc"; \
+	wget -O go.tgz "$url"; \
+	echo "$sha256 *go.tgz" | sha256sum -c -; \
+	\
+# https://github.com/golang/go/issues/14739#issuecomment-324767697
+	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+# https://www.google.com/linuxrepositories/
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
+# let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys '2F52 8D36 D67B 69ED F998  D857 78BD 6547 3CB3 BD13'; \
+	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" go.tgz.asc; \
+	\
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+	if [ -n "$build" ]; then \
+		apk add --no-cache --virtual .build-deps \
+			bash \
+			gcc \
+			go \
+			musl-dev \
+		; \
+		\
+		export GOCACHE='/tmp/gocache'; \
+		\
+		( \
+			cd /usr/local/go/src; \
+# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
+			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
+			if [ "${GOARCH:-}" = '386' ]; then \
+# https://github.com/golang/go/issues/52919; https://github.com/docker-library/golang/pull/426#issuecomment-1152623837
+				export CGO_CFLAGS='-fno-stack-protector'; \
+			fi; \
+			./make.bash; \
+		); \
+		\
+		apk del --no-network .build-deps; \
+		\
+# remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
+		rm -rf \
+			/usr/local/go/pkg/*/cmd \
+			/usr/local/go/pkg/bootstrap \
+			/usr/local/go/pkg/obj \
+			/usr/local/go/pkg/tool/*/api \
+			/usr/local/go/pkg/tool/*/go_bootstrap \
+			/usr/local/go/src/cmd/dist/dist \
+			"$GOCACHE" \
+		; \
+	fi; \
+	\
+	apk del --no-network .fetch-deps; \
+	\
+	go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
+WORKDIR $GOPATH

--- a/1.19/bookworm/Dockerfile
+++ b/1.19/bookworm/Dockerfile
@@ -1,0 +1,128 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM buildpack-deps:bookworm-scm
+
+# install cgo-related dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		g++ \
+		gcc \
+		libc6-dev \
+		make \
+		pkg-config \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+ENV PATH /usr/local/go/bin:$PATH
+
+ENV GOLANG_VERSION 1.19.13
+
+RUN set -eux; \
+	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
+	url=; \
+	case "$arch" in \
+		'amd64') \
+			url='https://dl.google.com/go/go1.19.13.linux-amd64.tar.gz'; \
+			sha256='4643d4c29c55f53fa0349367d7f1bb5ca554ea6ef528c146825b0f8464e2e668'; \
+			;; \
+		'armel') \
+			export GOARCH='arm' GOARM='5' GOOS='linux'; \
+			;; \
+		'armhf') \
+			url='https://dl.google.com/go/go1.19.13.linux-armv6l.tar.gz'; \
+			sha256='9dfd42b41057514454134552854cd1a5a47d501b760c87e9b0d3b0665374d8d9'; \
+			;; \
+		'arm64') \
+			url='https://dl.google.com/go/go1.19.13.linux-arm64.tar.gz'; \
+			sha256='1142ada7bba786d299812b23edd446761a54efbbcde346c2f0bc69ca6a007b58'; \
+			;; \
+		'i386') \
+			url='https://dl.google.com/go/go1.19.13.linux-386.tar.gz'; \
+			sha256='8368a9fdb3ab78da1ce75b80dc765c2814ca42afc2cf7e7dc45a1a61eaea22be'; \
+			;; \
+		'mips64el') \
+			export GOARCH='mips64le' GOOS='linux'; \
+			;; \
+		'ppc64el') \
+			url='https://dl.google.com/go/go1.19.13.linux-ppc64le.tar.gz'; \
+			sha256='fe02b81fd18913a19de420929f1fc2698eea15e90ad1d13471168fcdabe3aaff'; \
+			;; \
+		'riscv64') \
+			export GOARCH='riscv64' GOOS='linux'; \
+			;; \
+		's390x') \
+			url='https://dl.google.com/go/go1.19.13.linux-s390x.tar.gz'; \
+			sha256='af324cb46b268722e8ed3c7ecac87af4ee288ccb50be30ce2184fa7210495fb9'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
+	esac; \
+	build=; \
+	if [ -z "$url" ]; then \
+# https://github.com/golang/go/issues/38536#issuecomment-616897960
+		build=1; \
+		url='https://dl.google.com/go/go1.19.13.src.tar.gz'; \
+		sha256='ccf36b53fb0024a017353c3ddb22c1f00bc7a8073c6aac79042da24ee34434d3'; \
+		echo >&2; \
+		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
+		echo >&2; \
+	fi; \
+	\
+	wget -O go.tgz.asc "$url.asc"; \
+	wget -O go.tgz "$url" --progress=dot:giga; \
+	echo "$sha256 *go.tgz" | sha256sum -c -; \
+	\
+# https://github.com/golang/go/issues/14739#issuecomment-324767697
+	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+# https://www.google.com/linuxrepositories/
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
+# let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys '2F52 8D36 D67B 69ED F998  D857 78BD 6547 3CB3 BD13'; \
+	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" go.tgz.asc; \
+	\
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+	if [ -n "$build" ]; then \
+		savedAptMark="$(apt-mark showmanual)"; \
+		apt-get update; \
+		apt-get install -y --no-install-recommends golang-go; \
+		\
+		export GOCACHE='/tmp/gocache'; \
+		\
+		( \
+			cd /usr/local/go/src; \
+# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
+			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
+			./make.bash; \
+		); \
+		\
+		apt-mark auto '.*' > /dev/null; \
+		apt-mark manual $savedAptMark > /dev/null; \
+		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+		rm -rf /var/lib/apt/lists/*; \
+		\
+# remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
+		rm -rf \
+			/usr/local/go/pkg/*/cmd \
+			/usr/local/go/pkg/bootstrap \
+			/usr/local/go/pkg/obj \
+			/usr/local/go/pkg/tool/*/api \
+			/usr/local/go/pkg/tool/*/go_bootstrap \
+			/usr/local/go/src/cmd/dist/dist \
+			"$GOCACHE" \
+		; \
+	fi; \
+	\
+	go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
+WORKDIR $GOPATH

--- a/1.19/bullseye/Dockerfile
+++ b/1.19/bullseye/Dockerfile
@@ -1,0 +1,128 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM buildpack-deps:bullseye-scm
+
+# install cgo-related dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		g++ \
+		gcc \
+		libc6-dev \
+		make \
+		pkg-config \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+ENV PATH /usr/local/go/bin:$PATH
+
+ENV GOLANG_VERSION 1.19.13
+
+RUN set -eux; \
+	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
+	url=; \
+	case "$arch" in \
+		'amd64') \
+			url='https://dl.google.com/go/go1.19.13.linux-amd64.tar.gz'; \
+			sha256='4643d4c29c55f53fa0349367d7f1bb5ca554ea6ef528c146825b0f8464e2e668'; \
+			;; \
+		'armel') \
+			export GOARCH='arm' GOARM='5' GOOS='linux'; \
+			;; \
+		'armhf') \
+			url='https://dl.google.com/go/go1.19.13.linux-armv6l.tar.gz'; \
+			sha256='9dfd42b41057514454134552854cd1a5a47d501b760c87e9b0d3b0665374d8d9'; \
+			;; \
+		'arm64') \
+			url='https://dl.google.com/go/go1.19.13.linux-arm64.tar.gz'; \
+			sha256='1142ada7bba786d299812b23edd446761a54efbbcde346c2f0bc69ca6a007b58'; \
+			;; \
+		'i386') \
+			url='https://dl.google.com/go/go1.19.13.linux-386.tar.gz'; \
+			sha256='8368a9fdb3ab78da1ce75b80dc765c2814ca42afc2cf7e7dc45a1a61eaea22be'; \
+			;; \
+		'mips64el') \
+			export GOARCH='mips64le' GOOS='linux'; \
+			;; \
+		'ppc64el') \
+			url='https://dl.google.com/go/go1.19.13.linux-ppc64le.tar.gz'; \
+			sha256='fe02b81fd18913a19de420929f1fc2698eea15e90ad1d13471168fcdabe3aaff'; \
+			;; \
+		'riscv64') \
+			export GOARCH='riscv64' GOOS='linux'; \
+			;; \
+		's390x') \
+			url='https://dl.google.com/go/go1.19.13.linux-s390x.tar.gz'; \
+			sha256='af324cb46b268722e8ed3c7ecac87af4ee288ccb50be30ce2184fa7210495fb9'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
+	esac; \
+	build=; \
+	if [ -z "$url" ]; then \
+# https://github.com/golang/go/issues/38536#issuecomment-616897960
+		build=1; \
+		url='https://dl.google.com/go/go1.19.13.src.tar.gz'; \
+		sha256='ccf36b53fb0024a017353c3ddb22c1f00bc7a8073c6aac79042da24ee34434d3'; \
+		echo >&2; \
+		echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
+		echo >&2; \
+	fi; \
+	\
+	wget -O go.tgz.asc "$url.asc"; \
+	wget -O go.tgz "$url" --progress=dot:giga; \
+	echo "$sha256 *go.tgz" | sha256sum -c -; \
+	\
+# https://github.com/golang/go/issues/14739#issuecomment-324767697
+	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+# https://www.google.com/linuxrepositories/
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
+# let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys '2F52 8D36 D67B 69ED F998  D857 78BD 6547 3CB3 BD13'; \
+	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" go.tgz.asc; \
+	\
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+	if [ -n "$build" ]; then \
+		savedAptMark="$(apt-mark showmanual)"; \
+		apt-get update; \
+		apt-get install -y --no-install-recommends golang-go; \
+		\
+		export GOCACHE='/tmp/gocache'; \
+		\
+		( \
+			cd /usr/local/go/src; \
+# set GOROOT_BOOTSTRAP + GOHOST* such that we can build Go successfully
+			export GOROOT_BOOTSTRAP="$(go env GOROOT)" GOHOSTOS="$GOOS" GOHOSTARCH="$GOARCH"; \
+			./make.bash; \
+		); \
+		\
+		apt-mark auto '.*' > /dev/null; \
+		apt-mark manual $savedAptMark > /dev/null; \
+		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+		rm -rf /var/lib/apt/lists/*; \
+		\
+# remove a few intermediate / bootstrapping files the official binary release tarballs do not contain
+		rm -rf \
+			/usr/local/go/pkg/*/cmd \
+			/usr/local/go/pkg/bootstrap \
+			/usr/local/go/pkg/obj \
+			/usr/local/go/pkg/tool/*/api \
+			/usr/local/go/pkg/tool/*/go_bootstrap \
+			/usr/local/go/src/cmd/dist/dist \
+			"$GOCACHE" \
+		; \
+	fi; \
+	\
+	go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
+WORKDIR $GOPATH

--- a/1.19/windows/nanoserver-1809/Dockerfile
+++ b/1.19/windows/nanoserver-1809/Dockerfile
@@ -1,0 +1,30 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+SHELL ["cmd", "/S", "/C"]
+
+# no Git installed (intentionally)
+#  -- Nano Server is "Windows Slim"
+
+# for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
+ENV GOPATH C:\\go
+# HOWEVER, please note that it is the Go upstream intention to remove GOPATH support entirely: https://blog.golang.org/go116-module-changes
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+USER ContainerAdministrator
+RUN setx /m PATH "%GOPATH%\bin;C:\Program Files\Go\bin;%PATH%"
+USER ContainerUser
+# doing this first to share cache across versions more aggressively
+
+ENV GOLANG_VERSION 1.19.13
+
+# Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
+COPY --from=golang:1.19.13-windowsservercore-1809 ["C:\\\\Program Files\\\\Go","C:\\\\Program Files\\\\Go"]
+RUN go version
+
+WORKDIR $GOPATH

--- a/1.19/windows/nanoserver-ltsc2022/Dockerfile
+++ b/1.19/windows/nanoserver-ltsc2022/Dockerfile
@@ -1,0 +1,30 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
+
+SHELL ["cmd", "/S", "/C"]
+
+# no Git installed (intentionally)
+#  -- Nano Server is "Windows Slim"
+
+# for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
+ENV GOPATH C:\\go
+# HOWEVER, please note that it is the Go upstream intention to remove GOPATH support entirely: https://blog.golang.org/go116-module-changes
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+USER ContainerAdministrator
+RUN setx /m PATH "%GOPATH%\bin;C:\Program Files\Go\bin;%PATH%"
+USER ContainerUser
+# doing this first to share cache across versions more aggressively
+
+ENV GOLANG_VERSION 1.19.13
+
+# Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
+COPY --from=golang:1.19.13-windowsservercore-ltsc2022 ["C:\\\\Program Files\\\\Go","C:\\\\Program Files\\\\Go"]
+RUN go version
+
+WORKDIR $GOPATH

--- a/1.19/windows/windowsservercore-1809/Dockerfile
+++ b/1.19/windows/windowsservercore-1809/Dockerfile
@@ -1,0 +1,84 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/servercore:1809
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# install MinGit (especially for "go get")
+# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
+# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
+# "It currently requires only ~45MB on disk."
+ENV GIT_VERSION 2.23.0
+ENV GIT_TAG v${GIT_VERSION}.windows.1
+ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${GIT_TAG}/MinGit-${GIT_VERSION}-64-bit.zip
+ENV GIT_DOWNLOAD_SHA256 8f65208f92c0b4c3ae4c0cf02d4b5f6791d539cd1a07b2df62b7116467724735
+# steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
+RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:GIT_DOWNLOAD_URL -OutFile 'git.zip'; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_DOWNLOAD_SHA256); \
+	if ((Get-FileHash git.zip -Algorithm sha256).Hash -ne $env:GIT_DOWNLOAD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive -Path git.zip -DestinationPath C:\git\.; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item git.zip -Force; \
+	\
+	Write-Host 'Updating PATH ...'; \
+	$env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ("git version") ...'; \
+	git version; \
+	\
+	Write-Host 'Complete.';
+
+# for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
+ENV GOPATH C:\\go
+# HOWEVER, please note that it is the Go upstream intention to remove GOPATH support entirely: https://blog.golang.org/go116-module-changes
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
+# doing this first to share cache across versions more aggressively
+
+ENV GOLANG_VERSION 1.19.13
+
+RUN $url = 'https://dl.google.com/go/go1.19.13.windows-amd64.zip'; \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
+	\
+	$sha256 = '908cba438f6f34fdf5ec8572f5f8759cb85b87f5c0b4fc4a389249bf92b86736'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
+	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive go.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Moving ...'; \
+	Move-Item -Path C:\go -Destination 'C:\Program Files\Go'; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
+	\
+	Write-Host 'Complete.';
+
+WORKDIR $GOPATH

--- a/1.19/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/1.19/windows/windowsservercore-ltsc2022/Dockerfile
@@ -1,0 +1,84 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# install MinGit (especially for "go get")
+# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
+# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
+# "It currently requires only ~45MB on disk."
+ENV GIT_VERSION 2.23.0
+ENV GIT_TAG v${GIT_VERSION}.windows.1
+ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${GIT_TAG}/MinGit-${GIT_VERSION}-64-bit.zip
+ENV GIT_DOWNLOAD_SHA256 8f65208f92c0b4c3ae4c0cf02d4b5f6791d539cd1a07b2df62b7116467724735
+# steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
+RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:GIT_DOWNLOAD_URL -OutFile 'git.zip'; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_DOWNLOAD_SHA256); \
+	if ((Get-FileHash git.zip -Algorithm sha256).Hash -ne $env:GIT_DOWNLOAD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive -Path git.zip -DestinationPath C:\git\.; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item git.zip -Force; \
+	\
+	Write-Host 'Updating PATH ...'; \
+	$env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ("git version") ...'; \
+	git version; \
+	\
+	Write-Host 'Complete.';
+
+# for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
+ENV GOPATH C:\\go
+# HOWEVER, please note that it is the Go upstream intention to remove GOPATH support entirely: https://blog.golang.org/go116-module-changes
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
+# doing this first to share cache across versions more aggressively
+
+ENV GOLANG_VERSION 1.19.13
+
+RUN $url = 'https://dl.google.com/go/go1.19.13.windows-amd64.zip'; \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
+	\
+	$sha256 = '908cba438f6f34fdf5ec8572f5f8759cb85b87f5c0b4fc4a389249bf92b86736'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
+	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive go.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Moving ...'; \
+	Move-Item -Path C:\go -Destination 'C:\Program Files\Go'; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
+	\
+	Write-Host 'Complete.';
+
+WORKDIR $GOPATH

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -7,7 +7,7 @@
 	;
 	def always_build_from_source:
 		# https://github.com/golang/go/issues/57007! (as of Go 1.21, the upstream release binaries are fully static and thus appropriate for Alpine)
-		is_alpine and ([ "1.20" ] | index(env.version | rtrimstr("-rc")))
+		is_alpine and ([ "1.19", "1.20" ] | index(env.version | rtrimstr("-rc")))
 -}}
 {{ if is_alpine then ( -}}
 FROM alpine:{{ alpine_version }}
@@ -144,7 +144,7 @@ RUN set -eux; \
 		; \
 {{ ) else ( -}}
 		savedAptMark="$(apt-mark showmanual)"; \
-{{ if env.variant != "bullseye" then ( -}}
+{{ if [ "1.19" ] | index(env.version) or env.variant != "bullseye" then ( -}}
 		apt-get update; \
 		apt-get install -y --no-install-recommends golang-go; \
 {{ ) else ( -}}

--- a/versions.json
+++ b/versions.json
@@ -1,4 +1,176 @@
 {
+  "1.19": {
+    "arches": {
+      "amd64": {
+        "env": {
+          "GOAMD64": "v1",
+          "GOARCH": "amd64",
+          "GOOS": "linux"
+        },
+        "sha256": "4643d4c29c55f53fa0349367d7f1bb5ca554ea6ef528c146825b0f8464e2e668",
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.19.13.linux-amd64.tar.gz"
+      },
+      "arm32v5": {
+        "env": {
+          "GOARCH": "arm",
+          "GOARM": "5",
+          "GOOS": "linux"
+        },
+        "supported": true
+      },
+      "arm32v6": {
+        "env": {
+          "GOARCH": "arm",
+          "GOARM": "6",
+          "GOOS": "linux"
+        },
+        "sha256": "9dfd42b41057514454134552854cd1a5a47d501b760c87e9b0d3b0665374d8d9",
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.19.13.linux-armv6l.tar.gz"
+      },
+      "arm32v7": {
+        "env": {
+          "GOARCH": "arm",
+          "GOARM": "7",
+          "GOOS": "linux"
+        },
+        "sha256": "9dfd42b41057514454134552854cd1a5a47d501b760c87e9b0d3b0665374d8d9",
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.19.13.linux-armv6l.tar.gz"
+      },
+      "arm64v8": {
+        "env": {
+          "GOARCH": "arm64",
+          "GOOS": "linux"
+        },
+        "sha256": "1142ada7bba786d299812b23edd446761a54efbbcde346c2f0bc69ca6a007b58",
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.19.13.linux-arm64.tar.gz"
+      },
+      "darwin-amd64": {
+        "env": {
+          "GOARCH": "amd64",
+          "GOOS": "darwin"
+        },
+        "sha256": "1b4329dc9e73def7f894ca71fce78bb9f3f5c4c8671b6c7e4f363a3f47e88325",
+        "supported": false,
+        "url": "https://dl.google.com/go/go1.19.13.darwin-amd64.tar.gz"
+      },
+      "darwin-arm64v8": {
+        "env": {
+          "GOARCH": "arm64",
+          "GOOS": "darwin"
+        },
+        "sha256": "022b35fa9c79b9457fa4a14fd9c4cf5f8ea315a8f2e3b3cd949fea55e11a7d7b",
+        "supported": false,
+        "url": "https://dl.google.com/go/go1.19.13.darwin-arm64.tar.gz"
+      },
+      "freebsd-amd64": {
+        "env": {
+          "GOARCH": "amd64",
+          "GOOS": "freebsd"
+        },
+        "sha256": "97fd4990c5349ab922b9bf3e4c655e899135559ea6ad666d4b3c7a27b1e147a2",
+        "supported": false,
+        "url": "https://dl.google.com/go/go1.19.13.freebsd-amd64.tar.gz"
+      },
+      "freebsd-i386": {
+        "env": {
+          "GOARCH": "386",
+          "GOOS": "freebsd"
+        },
+        "sha256": "a0ad2dc1479310774ceba502c10097963637e398b235e48bbf26d8ed971b3fac",
+        "supported": false,
+        "url": "https://dl.google.com/go/go1.19.13.freebsd-386.tar.gz"
+      },
+      "i386": {
+        "env": {
+          "GO386": "softfloat",
+          "GOARCH": "386",
+          "GOOS": "linux"
+        },
+        "sha256": "8368a9fdb3ab78da1ce75b80dc765c2814ca42afc2cf7e7dc45a1a61eaea22be",
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.19.13.linux-386.tar.gz"
+      },
+      "mips64le": {
+        "env": {
+          "GOARCH": "mips64le",
+          "GOOS": "linux"
+        },
+        "supported": true
+      },
+      "ppc64le": {
+        "env": {
+          "GOARCH": "ppc64le",
+          "GOOS": "linux"
+        },
+        "sha256": "fe02b81fd18913a19de420929f1fc2698eea15e90ad1d13471168fcdabe3aaff",
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.19.13.linux-ppc64le.tar.gz"
+      },
+      "riscv64": {
+        "env": {
+          "GOARCH": "riscv64",
+          "GOOS": "linux"
+        },
+        "supported": true
+      },
+      "s390x": {
+        "env": {
+          "GOARCH": "s390x",
+          "GOOS": "linux"
+        },
+        "sha256": "af324cb46b268722e8ed3c7ecac87af4ee288ccb50be30ce2184fa7210495fb9",
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.19.13.linux-s390x.tar.gz"
+      },
+      "src": {
+        "sha256": "ccf36b53fb0024a017353c3ddb22c1f00bc7a8073c6aac79042da24ee34434d3",
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.19.13.src.tar.gz"
+      },
+      "windows-amd64": {
+        "env": {
+          "GOARCH": "amd64",
+          "GOOS": "windows"
+        },
+        "sha256": "908cba438f6f34fdf5ec8572f5f8759cb85b87f5c0b4fc4a389249bf92b86736",
+        "supported": true,
+        "url": "https://dl.google.com/go/go1.19.13.windows-amd64.zip"
+      },
+      "windows-arm64v8": {
+        "env": {
+          "GOARCH": "arm64",
+          "GOOS": "windows"
+        },
+        "sha256": "b1d103b1caece86cceb164fc2c6a941ab8aba74580fabf20a33dbb969b5a3b49",
+        "supported": false,
+        "url": "https://dl.google.com/go/go1.19.13.windows-arm64.zip"
+      },
+      "windows-i386": {
+        "env": {
+          "GOARCH": "386",
+          "GOOS": "windows"
+        },
+        "sha256": "9aba3b0f79883313e833263ffef4610980c2818786ee65d5382b659d05a55d3f",
+        "supported": false,
+        "url": "https://dl.google.com/go/go1.19.13.windows-386.zip"
+      }
+    },
+    "variants": [
+      "bookworm",
+      "bullseye",
+      "alpine3.18",
+      "alpine3.17",
+      "windows/windowsservercore-ltsc2022",
+      "windows/windowsservercore-1809",
+      "windows/nanoserver-ltsc2022",
+      "windows/nanoserver-1809"
+    ],
+    "version": "1.19.13"
+  },
   "1.20": {
     "arches": {
       "amd64": {


### PR DESCRIPTION
This reverts and updates commit 5eba309b53593d8c24a5a0164605f503f9108492.

> go1.19.13 (released 2023-09-06) includes fixes to the go command, and the crypto/tls and net/http packages.
>
> \- https://go.dev/doc/devel/release#go1.19.minor

> We have also released Go version 1.19.13, a minor point release that only includes fixes to improve its forward and backward compatibility.
>
> \- https://groups.google.com/g/golang-announce/c/Fm51GRLNRvM



Fixes #488