### PR TITLE
Set `GOTOOLCHAIN` to prevent go auto-upgrade

### DIFF
--- a/1.21/alpine3.17/Dockerfile
+++ b/1.21/alpine3.17/Dockerfile
@@ -118,6 +118,10 @@ RUN set -eux; \
 	\
 	go version
 
+# don't auto-upgrade the gotoolchain
+# https://github.com/docker-library/golang/issues/472
+ENV GOTOOLCHAIN=local
+
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"

--- a/1.21/alpine3.18/Dockerfile
+++ b/1.21/alpine3.18/Dockerfile
@@ -118,6 +118,10 @@ RUN set -eux; \
 	\
 	go version
 
+# don't auto-upgrade the gotoolchain
+# https://github.com/docker-library/golang/issues/472
+ENV GOTOOLCHAIN=local
+
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"

--- a/1.21/bookworm/Dockerfile
+++ b/1.21/bookworm/Dockerfile
@@ -124,6 +124,10 @@ RUN set -eux; \
 	\
 	go version
 
+# don't auto-upgrade the gotoolchain
+# https://github.com/docker-library/golang/issues/472
+ENV GOTOOLCHAIN=local
+
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"

--- a/1.21/bullseye/Dockerfile
+++ b/1.21/bullseye/Dockerfile
@@ -130,6 +130,10 @@ RUN set -eux; \
 	\
 	go version
 
+# don't auto-upgrade the gotoolchain
+# https://github.com/docker-library/golang/issues/472
+ENV GOTOOLCHAIN=local
+
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -201,6 +201,12 @@ RUN set -eux; \
 {{ ) else "" end -}}
 	go version
 
+{{ if [ "1.20" ] | index(env.version | rtrimstr("-rc")) then "" else ( -}}
+# don't auto-upgrade the gotoolchain
+# https://github.com/docker-library/golang/issues/472
+ENV GOTOOLCHAIN=local
+
+{{ ) end -}}
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"


### PR DESCRIPTION
Fixes https://github.com/docker-library/golang/issues/472

Using an image that is too old for your project's minimum `go` version will cause `go` to fail and help inform the user that they are not using a new enough `go` for their project. So, rather than having `go` automatically upgrading the toolchain (`GOTOOLCHAIN=auto`, the default), we have opted to move the image to encourage users to upgrade the image to get newer versions of `go`.

(See also the comments on #472)