### PR TITLE
Install git-lfs to support Go modules with large-files

### DIFF
--- a/1.20/alpine3.17/Dockerfile
+++ b/1.20/alpine3.17/Dockerfile
@@ -108,6 +108,9 @@ RUN set -eux; \
 	\
 	go version
 
+# install git-lfs for Go modules with LFS committed files
+RUN apk add --no-cache git-lfs
+
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"

--- a/1.20/alpine3.18/Dockerfile
+++ b/1.20/alpine3.18/Dockerfile
@@ -108,6 +108,9 @@ RUN set -eux; \
 	\
 	go version
 
+# install git-lfs for Go modules with LFS committed files
+RUN apk add --no-cache git-lfs
+
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"

--- a/1.20/bookworm/Dockerfile
+++ b/1.20/bookworm/Dockerfile
@@ -122,6 +122,12 @@ RUN set -eux; \
 	\
 	go version
 
+# install git-lfs for Go modules with LFS committed files
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends git-lfs; \
+	rm -rf /var/lib/apt/lists/*
+
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"

--- a/1.20/bullseye/Dockerfile
+++ b/1.20/bullseye/Dockerfile
@@ -128,6 +128,12 @@ RUN set -eux; \
 	\
 	go version
 
+# install git-lfs for Go modules with LFS committed files
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends git-lfs; \
+	rm -rf /var/lib/apt/lists/*
+
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"

--- a/1.21/alpine3.17/Dockerfile
+++ b/1.21/alpine3.17/Dockerfile
@@ -118,6 +118,9 @@ RUN set -eux; \
 	\
 	go version
 
+# install git-lfs for Go modules with LFS committed files
+RUN apk add --no-cache git-lfs
+
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"

--- a/1.21/alpine3.18/Dockerfile
+++ b/1.21/alpine3.18/Dockerfile
@@ -118,6 +118,9 @@ RUN set -eux; \
 	\
 	go version
 
+# install git-lfs for Go modules with LFS committed files
+RUN apk add --no-cache git-lfs
+
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"

--- a/1.21/bookworm/Dockerfile
+++ b/1.21/bookworm/Dockerfile
@@ -124,6 +124,12 @@ RUN set -eux; \
 	\
 	go version
 
+# install git-lfs for Go modules with LFS committed files
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends git-lfs; \
+	rm -rf /var/lib/apt/lists/*
+
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"

--- a/1.21/bullseye/Dockerfile
+++ b/1.21/bullseye/Dockerfile
@@ -130,6 +130,12 @@ RUN set -eux; \
 	\
 	go version
 
+# install git-lfs for Go modules with LFS committed files
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends git-lfs; \
+	rm -rf /var/lib/apt/lists/*
+
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -201,6 +201,16 @@ RUN set -eux; \
 {{ ) else "" end -}}
 	go version
 
+# install git-lfs for Go modules with LFS committed files
+{{ if is_alpine then ( -}}
+RUN apk add --no-cache git-lfs
+{{ ) else ( -}}
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends git-lfs; \
+	rm -rf /var/lib/apt/lists/*
+{{ ) end -}}
+
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"


### PR DESCRIPTION
This pull-request installs `git-lfs` on the Linux images to support the download of Go modules from private repositories. The following is true even for public repositories that are downloaded directly (as opposed to downloading from a module-proxy).

The Go toolchain uses the local git installation to fetch archives of modules from Git servers directly. My company commits large files using Git LFS which happen to be part of our Go module source tree. Without _git-lfs_ installed, the local git installation does not automatically resolve those files which causes "_checksum mismatch_" against the committed `go.sum`.

@yosifkit I have tested that the generated images in-fact resolve the Issue. I'd appreciate your review.
Looking for your guidance on getting this enhancement to the community,