### PR TITLE
Add Alpine 3.19 variant

### DIFF
--- a/1.20/alpine3.19/Dockerfile
+++ b/1.20/alpine3.19/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.17
+FROM alpine:3.19
 
 RUN apk add --no-cache ca-certificates
 

--- a/1.21/alpine3.19/Dockerfile
+++ b/1.21/alpine3.19/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.17
+FROM alpine:3.19
 
 RUN apk add --no-cache ca-certificates
 

--- a/versions.json
+++ b/versions.json
@@ -162,8 +162,8 @@
     "variants": [
       "bookworm",
       "bullseye",
+      "alpine3.19",
       "alpine3.18",
-      "alpine3.17",
       "windows/windowsservercore-ltsc2022",
       "windows/windowsservercore-1809",
       "windows/nanoserver-ltsc2022",
@@ -554,8 +554,8 @@
     "variants": [
       "bookworm",
       "bullseye",
+      "alpine3.19",
       "alpine3.18",
-      "alpine3.17",
       "windows/windowsservercore-ltsc2022",
       "windows/windowsservercore-1809",
       "windows/nanoserver-ltsc2022",

--- a/versions.sh
+++ b/versions.sh
@@ -148,8 +148,8 @@ for version in "${versions[@]}"; do
 			"bookworm",
 			"bullseye",
 			(
-				"3.18",
-				"3.17"
+				"3.19",
+				"3.18"
 			| "alpine" + .),
 			if .arches | has("windows-amd64") and .["windows-amd64"].url then
 				(


### PR DESCRIPTION
Modelled after #460.

This PR adds a variant for Alpine 3.19 and drops the 3.17 variant at the same time.

See also https://alpinelinux.org/posts/Alpine-3.19.0-released.html.

*~~Note: the Alpine 3.19 base Docker image is yet to appear [here](https://hub.docker.com/_/alpine/tags), so automated checks will fail up till then; see also https://github.com/docker-library/official-images/pull/15852.~~*

*Edit: the Alpine 3.19 base images are now available, so this is now ready for a retrigger of the workflow!*