### PR TITLE
Set GOARM=7 explicitly for arm32v7 images

### DIFF
--- a/1.21/alpine3.18/Dockerfile
+++ b/1.21/alpine3.18/Dockerfile
@@ -112,6 +112,15 @@ RUN set -eux; \
 			/usr/local/go/src/cmd/dist/dist \
 			"$GOCACHE" \
 		; \
+	elif [ "$arch" = 'armv7' ]; then \
+		[ -s /usr/local/go/go.env ]; \
+		before="$(go env GOARM)"; [ "$before" != '7' ]; \
+		{ \
+			echo; \
+			echo '# https://github.com/docker-library/golang/issues/494'; \
+			echo 'GOARM=7'; \
+		} >> /usr/local/go/go.env; \
+		after="$(go env GOARM)"; [ "$after" = '7' ]; \
 	fi; \
 	\
 	apk del --no-network .fetch-deps; \

--- a/1.21/alpine3.19/Dockerfile
+++ b/1.21/alpine3.19/Dockerfile
@@ -112,6 +112,15 @@ RUN set -eux; \
 			/usr/local/go/src/cmd/dist/dist \
 			"$GOCACHE" \
 		; \
+	elif [ "$arch" = 'armv7' ]; then \
+		[ -s /usr/local/go/go.env ]; \
+		before="$(go env GOARM)"; [ "$before" != '7' ]; \
+		{ \
+			echo; \
+			echo '# https://github.com/docker-library/golang/issues/494'; \
+			echo 'GOARM=7'; \
+		} >> /usr/local/go/go.env; \
+		after="$(go env GOARM)"; [ "$after" = '7' ]; \
 	fi; \
 	\
 	apk del --no-network .fetch-deps; \

--- a/1.21/bookworm/Dockerfile
+++ b/1.21/bookworm/Dockerfile
@@ -120,6 +120,15 @@ RUN set -eux; \
 			/usr/local/go/src/cmd/dist/dist \
 			"$GOCACHE" \
 		; \
+	elif [ "$arch" = 'armhf' ]; then \
+		[ -s /usr/local/go/go.env ]; \
+		before="$(go env GOARM)"; [ "$before" != '7' ]; \
+		{ \
+			echo; \
+			echo '# https://github.com/docker-library/golang/issues/494'; \
+			echo 'GOARM=7'; \
+		} >> /usr/local/go/go.env; \
+		after="$(go env GOARM)"; [ "$after" = '7' ]; \
 	fi; \
 	\
 	go version

--- a/1.21/bullseye/Dockerfile
+++ b/1.21/bullseye/Dockerfile
@@ -126,6 +126,15 @@ RUN set -eux; \
 			/usr/local/go/src/cmd/dist/dist \
 			"$GOCACHE" \
 		; \
+	elif [ "$arch" = 'armhf' ]; then \
+		[ -s /usr/local/go/go.env ]; \
+		before="$(go env GOARM)"; [ "$before" != '7' ]; \
+		{ \
+			echo; \
+			echo '# https://github.com/docker-library/golang/issues/494'; \
+			echo 'GOARM=7'; \
+		} >> /usr/local/go/go.env; \
+		after="$(go env GOARM)"; [ "$after" = '7' ]; \
 	fi; \
 	\
 	go version

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -193,6 +193,17 @@ RUN set -eux; \
 			/usr/local/go/src/cmd/dist/dist \
 			"$GOCACHE" \
 		; \
+{{ if [ "1.20" ] | index(env.version) then "" elif .arches["arm32v7"].url // "" | contains("armv6") then ( -}}
+	elif [ "$arch" = {{ os_arches["arm32v7"] | @sh }} ]; then \
+		[ -s /usr/local/go/go.env ]; \
+		before="$(go env GOARM)"; [ "$before" != {{ .arches["arm32v7"].env["GOARM"] | @sh }} ]; \
+		{ \
+			echo; \
+			echo '# https://github.com/docker-library/golang/issues/494'; \
+			echo {{ "GOARM=\(.arches["arm32v7"].env["GOARM"])" | @sh }}; \
+		} >> /usr/local/go/go.env; \
+		after="$(go env GOARM)"; [ "$after" = {{ .arches["arm32v7"].env["GOARM"] | @sh }} ]; \
+{{ ) else "" end -}}
 	fi; \
 	\
 {{ if is_alpine then ( -}}


### PR DESCRIPTION
This fixes the disparity between the "armv6" download of Go from upstream and the image being v7 otherwise (and thus the default value of `GOARM` being `6` instead of `7`, which is unexpected for users of the image).

This is set in such a way that environment variables (or `go env -w`) will override it, but without requiring us to recompile Go (which I'm not convinced gives us much gain -- happy to reconsider if someone comes up with a good way to benchmark the compiler).

Closes #494