### PR TITLE
Add Alpine 3.20 variant

### DIFF
--- a/1.21/alpine3.20/Dockerfile
+++ b/1.21/alpine3.20/Dockerfile
@@ -4,11 +4,11 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.18 AS build
+FROM alpine:3.20 AS build
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.22.3
+ENV GOLANG_VERSION 1.21.10
 
 RUN set -eux; \
 	apk add --no-cache --virtual .fetch-deps \
@@ -21,36 +21,36 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dl.google.com/go/go1.22.3.linux-amd64.tar.gz'; \
-			sha256='8920ea521bad8f6b7bc377b4824982e011c19af27df88a815e3586ea895f1b36'; \
+			url='https://dl.google.com/go/go1.21.10.linux-amd64.tar.gz'; \
+			sha256='e330e5d977bf4f3bdc157bc46cf41afa5b13d66c914e12fd6b694ccda65fcf92'; \
 			;; \
 		'armhf') \
-			url='https://dl.google.com/go/go1.22.3.linux-armv6l.tar.gz'; \
-			sha256='f2bacad20cd2b96f23a86d4826525d42b229fd431cc6d0dec61ff3bc448ef46e'; \
+			url='https://dl.google.com/go/go1.21.10.linux-armv6l.tar.gz'; \
+			sha256='15af2bcf7c916895f3e4bc16fb94d4ddfbe9ec6ba2b3e096679f4837dd6a72ae'; \
 			;; \
 		'armv7') \
-			url='https://dl.google.com/go/go1.22.3.linux-armv6l.tar.gz'; \
-			sha256='f2bacad20cd2b96f23a86d4826525d42b229fd431cc6d0dec61ff3bc448ef46e'; \
+			url='https://dl.google.com/go/go1.21.10.linux-armv6l.tar.gz'; \
+			sha256='15af2bcf7c916895f3e4bc16fb94d4ddfbe9ec6ba2b3e096679f4837dd6a72ae'; \
 			;; \
 		'aarch64') \
-			url='https://dl.google.com/go/go1.22.3.linux-arm64.tar.gz'; \
-			sha256='6c33e52a5b26e7aa021b94475587fce80043a727a54ceb0eee2f9fc160646434'; \
+			url='https://dl.google.com/go/go1.21.10.linux-arm64.tar.gz'; \
+			sha256='428e0b9ecab5762b7c2be000ad1be6f432dccfcd99bb8b8aeeb757d987bfda9d'; \
 			;; \
 		'x86') \
-			url='https://dl.google.com/go/go1.22.3.linux-386.tar.gz'; \
-			sha256='fefba30bb0d3dd1909823ee38c9f1930c3dc5337a2ac4701c2277a329a386b57'; \
+			url='https://dl.google.com/go/go1.21.10.linux-386.tar.gz'; \
+			sha256='06492fbb0bf06689dbab638a2d70e223c59a27bbd366219d011287b72747a38a'; \
 			;; \
 		'ppc64le') \
-			url='https://dl.google.com/go/go1.22.3.linux-ppc64le.tar.gz'; \
-			sha256='04b7b05283de30dd2da20bf3114b2e22cc727938aed3148babaf35cc951051ac'; \
+			url='https://dl.google.com/go/go1.21.10.linux-ppc64le.tar.gz'; \
+			sha256='069869a483e1e4823dd125ef1a30c2f4c4be7c290e50ed3b4bb0e78614c1e69c'; \
 			;; \
 		'riscv64') \
-			url='https://dl.google.com/go/go1.22.3.linux-riscv64.tar.gz'; \
-			sha256='d4992d4a85696e3f1de06cefbfc2fd840c9c6695d77a0f35cfdc4e28b2121c20'; \
+			url='https://dl.google.com/go/go1.21.10.linux-riscv64.tar.gz'; \
+			sha256='710dcbe80e967a1a99b8021392c5d5fa052bd8e9dd6b402c973550b3738b1eda'; \
 			;; \
 		's390x') \
-			url='https://dl.google.com/go/go1.22.3.linux-s390x.tar.gz'; \
-			sha256='2aba796417a69be5f3ed489076bac79c1c02b36e29422712f9f3bf51da9cf2d4'; \
+			url='https://dl.google.com/go/go1.21.10.linux-s390x.tar.gz'; \
+			sha256='527ad992ec891626e5a46406a89ad877e1a547cca9ecf93542eb0595261e5080'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
@@ -100,11 +100,11 @@ RUN set -eux; \
 	epoch="$(stat -c '%Y' /usr/local/go)"; \
 	[ "$SOURCE_DATE_EPOCH" = "$epoch" ]
 
-FROM alpine:3.18
+FROM alpine:3.20
 
 RUN apk add --no-cache ca-certificates
 
-ENV GOLANG_VERSION 1.22.3
+ENV GOLANG_VERSION 1.21.10
 
 # don't auto-upgrade the gotoolchain
 # https://github.com/docker-library/golang/issues/472

--- a/1.22/alpine3.20/Dockerfile
+++ b/1.22/alpine3.20/Dockerfile
@@ -4,11 +4,11 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.18 AS build
+FROM alpine:3.20 AS build
 
 ENV PATH /usr/local/go/bin:$PATH
 
-ENV GOLANG_VERSION 1.21.10
+ENV GOLANG_VERSION 1.22.3
 
 RUN set -eux; \
 	apk add --no-cache --virtual .fetch-deps \
@@ -21,36 +21,36 @@ RUN set -eux; \
 	url=; \
 	case "$arch" in \
 		'x86_64') \
-			url='https://dl.google.com/go/go1.21.10.linux-amd64.tar.gz'; \
-			sha256='e330e5d977bf4f3bdc157bc46cf41afa5b13d66c914e12fd6b694ccda65fcf92'; \
+			url='https://dl.google.com/go/go1.22.3.linux-amd64.tar.gz'; \
+			sha256='8920ea521bad8f6b7bc377b4824982e011c19af27df88a815e3586ea895f1b36'; \
 			;; \
 		'armhf') \
-			url='https://dl.google.com/go/go1.21.10.linux-armv6l.tar.gz'; \
-			sha256='15af2bcf7c916895f3e4bc16fb94d4ddfbe9ec6ba2b3e096679f4837dd6a72ae'; \
+			url='https://dl.google.com/go/go1.22.3.linux-armv6l.tar.gz'; \
+			sha256='f2bacad20cd2b96f23a86d4826525d42b229fd431cc6d0dec61ff3bc448ef46e'; \
 			;; \
 		'armv7') \
-			url='https://dl.google.com/go/go1.21.10.linux-armv6l.tar.gz'; \
-			sha256='15af2bcf7c916895f3e4bc16fb94d4ddfbe9ec6ba2b3e096679f4837dd6a72ae'; \
+			url='https://dl.google.com/go/go1.22.3.linux-armv6l.tar.gz'; \
+			sha256='f2bacad20cd2b96f23a86d4826525d42b229fd431cc6d0dec61ff3bc448ef46e'; \
 			;; \
 		'aarch64') \
-			url='https://dl.google.com/go/go1.21.10.linux-arm64.tar.gz'; \
-			sha256='428e0b9ecab5762b7c2be000ad1be6f432dccfcd99bb8b8aeeb757d987bfda9d'; \
+			url='https://dl.google.com/go/go1.22.3.linux-arm64.tar.gz'; \
+			sha256='6c33e52a5b26e7aa021b94475587fce80043a727a54ceb0eee2f9fc160646434'; \
 			;; \
 		'x86') \
-			url='https://dl.google.com/go/go1.21.10.linux-386.tar.gz'; \
-			sha256='06492fbb0bf06689dbab638a2d70e223c59a27bbd366219d011287b72747a38a'; \
+			url='https://dl.google.com/go/go1.22.3.linux-386.tar.gz'; \
+			sha256='fefba30bb0d3dd1909823ee38c9f1930c3dc5337a2ac4701c2277a329a386b57'; \
 			;; \
 		'ppc64le') \
-			url='https://dl.google.com/go/go1.21.10.linux-ppc64le.tar.gz'; \
-			sha256='069869a483e1e4823dd125ef1a30c2f4c4be7c290e50ed3b4bb0e78614c1e69c'; \
+			url='https://dl.google.com/go/go1.22.3.linux-ppc64le.tar.gz'; \
+			sha256='04b7b05283de30dd2da20bf3114b2e22cc727938aed3148babaf35cc951051ac'; \
 			;; \
 		'riscv64') \
-			url='https://dl.google.com/go/go1.21.10.linux-riscv64.tar.gz'; \
-			sha256='710dcbe80e967a1a99b8021392c5d5fa052bd8e9dd6b402c973550b3738b1eda'; \
+			url='https://dl.google.com/go/go1.22.3.linux-riscv64.tar.gz'; \
+			sha256='d4992d4a85696e3f1de06cefbfc2fd840c9c6695d77a0f35cfdc4e28b2121c20'; \
 			;; \
 		's390x') \
-			url='https://dl.google.com/go/go1.21.10.linux-s390x.tar.gz'; \
-			sha256='527ad992ec891626e5a46406a89ad877e1a547cca9ecf93542eb0595261e5080'; \
+			url='https://dl.google.com/go/go1.22.3.linux-s390x.tar.gz'; \
+			sha256='2aba796417a69be5f3ed489076bac79c1c02b36e29422712f9f3bf51da9cf2d4'; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
 	esac; \
@@ -100,11 +100,11 @@ RUN set -eux; \
 	epoch="$(stat -c '%Y' /usr/local/go)"; \
 	[ "$SOURCE_DATE_EPOCH" = "$epoch" ]
 
-FROM alpine:3.18
+FROM alpine:3.20
 
 RUN apk add --no-cache ca-certificates
 
-ENV GOLANG_VERSION 1.21.10
+ENV GOLANG_VERSION 1.22.3
 
 # don't auto-upgrade the gotoolchain
 # https://github.com/docker-library/golang/issues/472

--- a/versions.json
+++ b/versions.json
@@ -383,8 +383,8 @@
     "variants": [
       "bookworm",
       "bullseye",
+      "alpine3.20",
       "alpine3.19",
-      "alpine3.18",
       "windows/windowsservercore-ltsc2022",
       "windows/windowsservercore-1809",
       "windows/nanoserver-ltsc2022",
@@ -775,8 +775,8 @@
     "variants": [
       "bookworm",
       "bullseye",
+      "alpine3.20",
       "alpine3.19",
-      "alpine3.18",
       "windows/windowsservercore-ltsc2022",
       "windows/windowsservercore-1809",
       "windows/nanoserver-ltsc2022",

--- a/versions.sh
+++ b/versions.sh
@@ -155,8 +155,8 @@ for version in "${versions[@]}"; do
 			"bookworm",
 			"bullseye",
 			(
+				"3.20",
 				"3.19",
-				"3.18",
 				empty
 			| "alpine" + .),
 			if .arches | has("windows-amd64") and .["windows-amd64"].url then


### PR DESCRIPTION
Modelled after #497.

Requires https://github.com/docker-library/official-images/pull/16801.

This PR adds a variant for Alpine 3.20 and drops the 3.18 variant at the same time.

See also https://alpinelinux.org/posts/Alpine-3.20.0-released.html.