### PR TITLE
Add go1.22.5-alpine.18

### DIFF
--- a/1.22/alpine3.18/Dockerfile
+++ b/1.22/alpine3.18/Dockerfile
@@ -1,0 +1,128 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM alpine:3.18 AS build
+
+ENV PATH /usr/local/go/bin:$PATH
+
+ENV GOLANG_VERSION 1.22.5
+
+RUN set -eux; \
+	now="$(date '+%s')"; \
+	apk add --no-cache --virtual .fetch-deps \
+		ca-certificates \
+		gnupg \
+# busybox's "tar" doesn't handle directory mtime correctly, so our SOURCE_DATE_EPOCH lookup doesn't work (the mtime of "/usr/local/go" always ends up being the extraction timestamp)
+		tar \
+	; \
+	arch="$(apk --print-arch)"; \
+	url=; \
+	case "$arch" in \
+		'x86_64') \
+			url='https://dl.google.com/go/go1.22.5.linux-amd64.tar.gz'; \
+			sha256='904b924d435eaea086515bc63235b192ea441bd8c9b198c507e85009e6e4c7f0'; \
+			;; \
+		'armhf') \
+			url='https://dl.google.com/go/go1.22.5.linux-armv6l.tar.gz'; \
+			sha256='8c4587cf3e63c9aefbcafa92818c4d9d51683af93ea687bf6c7508d6fa36f85e'; \
+			;; \
+		'armv7') \
+			url='https://dl.google.com/go/go1.22.5.linux-armv6l.tar.gz'; \
+			sha256='8c4587cf3e63c9aefbcafa92818c4d9d51683af93ea687bf6c7508d6fa36f85e'; \
+			;; \
+		'aarch64') \
+			url='https://dl.google.com/go/go1.22.5.linux-arm64.tar.gz'; \
+			sha256='8d21325bfcf431be3660527c1a39d3d9ad71535fabdf5041c826e44e31642b5a'; \
+			;; \
+		'x86') \
+			url='https://dl.google.com/go/go1.22.5.linux-386.tar.gz'; \
+			sha256='3ea4c78e6fa52978ae1ed2e5927ad17495da440c9fae7787b1ebc1d0572f7f43'; \
+			;; \
+		'ppc64le') \
+			url='https://dl.google.com/go/go1.22.5.linux-ppc64le.tar.gz'; \
+			sha256='5312bb420ac0b59175a58927e70b4660b14ab7319aab54398b6071fabcbfbb09'; \
+			;; \
+		'riscv64') \
+			url='https://dl.google.com/go/go1.22.5.linux-riscv64.tar.gz'; \
+			sha256='f8d0c7d96b336f4133409ff9da7241cfe91e65723c2e8e7c7f9b58a9f9603476'; \
+			;; \
+		's390x') \
+			url='https://dl.google.com/go/go1.22.5.linux-s390x.tar.gz'; \
+			sha256='24c6c5c9d515adea5d58ae78388348c97614a0c21ac4d4f4c0dab75e893b0b5d'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
+	esac; \
+	\
+	wget -O go.tgz.asc "$url.asc"; \
+	wget -O go.tgz "$url"; \
+	echo "$sha256 *go.tgz" | sha256sum -c -; \
+	\
+# https://github.com/golang/go/issues/14739#issuecomment-324767697
+	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+# https://www.google.com/linuxrepositories/
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
+# let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys '2F52 8D36 D67B 69ED F998  D857 78BD 6547 3CB3 BD13'; \
+	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" go.tgz.asc; \
+	\
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+# save the timestamp from the tarball so we can restore it for reproducibility, if necessary (see below)
+	SOURCE_DATE_EPOCH="$(stat -c '%Y' /usr/local/go)"; \
+	export SOURCE_DATE_EPOCH; \
+	touchy="$(date -d "@$SOURCE_DATE_EPOCH" '+%Y%m%d%H%M.%S')"; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
+# sanity check (detected value should be older than our wall clock)
+	[ "$SOURCE_DATE_EPOCH" -lt "$now" ]; \
+	\
+	if [ "$arch" = 'armv7' ]; then \
+		[ -s /usr/local/go/go.env ]; \
+		before="$(go env GOARM)"; [ "$before" != '7' ]; \
+		{ \
+			echo; \
+			echo '# https://github.com/docker-library/golang/issues/494'; \
+			echo 'GOARM=7'; \
+		} >> /usr/local/go/go.env; \
+		after="$(go env GOARM)"; [ "$after" = '7' ]; \
+# (re-)clamp timestamp for reproducibility (allows "COPY --link" to be more clever/useful)
+		touch -t "$touchy" /usr/local/go/go.env /usr/local/go; \
+	fi; \
+	\
+# ideally at this point, we would just "COPY --link ... /usr/local/go/ /usr/local/go/" but BuildKit insists on creating the parent directories (perhaps related to https://github.com/opencontainers/image-spec/pull/970), and does so with unreproducible timestamps, so we instead create a whole new "directory tree" that we can "COPY --link" to accomplish what we want
+	mkdir /target /target/usr /target/usr/local; \
+	mv -vT /usr/local/go /target/usr/local/go; \
+	ln -svfT /target/usr/local/go /usr/local/go; \
+	touch -t "$touchy" /target/usr/local /target/usr /target; \
+	\
+	apk del --no-network .fetch-deps; \
+	\
+# smoke test
+	go version; \
+# make sure our reproducibile timestamp is probably still correct (best-effort inline reproducibility test)
+	epoch="$(stat -c '%Y' /target/usr/local/go)"; \
+	[ "$SOURCE_DATE_EPOCH" = "$epoch" ]; \
+	find /target -newer /target/usr/local/go -exec sh -c 'ls -ld "$@" && exit "$#"' -- '{}' +
+
+FROM alpine:3.18
+
+RUN apk add --no-cache ca-certificates
+
+ENV GOLANG_VERSION 1.22.5
+
+# don't auto-upgrade the gotoolchain
+# https://github.com/docker-library/golang/issues/472
+ENV GOTOOLCHAIN=local
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+# (see notes above about "COPY --link")
+COPY --from=build --link /target/ /
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
+WORKDIR $GOPATH

--- a/versions.json
+++ b/versions.json
@@ -786,6 +786,7 @@
       "bullseye",
       "alpine3.20",
       "alpine3.19",
+      "alpine3.18",
       "windows/windowsservercore-ltsc2022",
       "windows/windowsservercore-1809",
       "windows/nanoserver-ltsc2022",

--- a/versions.sh
+++ b/versions.sh
@@ -157,6 +157,7 @@ for version in "${versions[@]}"; do
 			(
 				"3.20",
 				"3.19",
+				"3.18",
 				empty
 			| "alpine" + .),
 			if .arches | has("windows-amd64") and .["windows-amd64"].url then


### PR DESCRIPTION
[When using wasmvm < v2.1.0, can't build with latest version in go1.22 line with alpine > v3.18](https://github.com/CosmWasm/wasmvm/issues/523)

This PR aims to create a go1.22.5-alpine3.18 image published to the official golang hub.docker so it can be reused easily.