### PR TITLE
Add GOARM64 and GORISCV64 values to our `versions.json`

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -455,7 +455,8 @@
         "sha256": "62788056693009bcf7020eedc778cdd1781941c6145eab7688bd087bce0f8659",
         "env": {
           "GOOS": "linux",
-          "GOARCH": "arm64"
+          "GOARCH": "arm64",
+          "GOARM64": "v8.0"
         },
         "supported": true
       },
@@ -735,7 +736,8 @@
         "sha256": "a87726205f1a283247f877ccae8ce147ff4e77ac802382647ac52256eb5642c7",
         "env": {
           "GOOS": "linux",
-          "GOARCH": "riscv64"
+          "GOARCH": "riscv64",
+          "GORISCV64": "rva20u64"
         },
         "supported": true
       },

--- a/versions.sh
+++ b/versions.sh
@@ -140,11 +140,18 @@ for version in "${versions[@]}"; do
 							# i386 in Debian is non-SSE2, Alpine appears to be similar (but interesting, not FreeBSD?)
 							{ GOARCH: "386", GO386: "softfloat" }
 						elif $bashbrewArch == "amd64" then
-							# https://tip.golang.org/doc/go1.18#amd64
+							# https://go.dev/doc/go1.18#amd64
 							{ GOAMD64: "v1" }
 						# TODO ^^ figure out what to do with GOAMD64 / GO386 if/when the OS baselines change and these choices needs to be per-variant /o\ (probably move it to the template instead, in fact, since that is where we can most easily toggle based on variant)
+						elif $bashbrewArch == "riscv64" and env.version != "1.22" then
+							# https://go.dev/doc/go1.23#riscv
+							{ GORISCV64: "rva20u64" }
 						elif $bashbrewArch | startswith("arm64v") then
-							{ GOARCH: "arm64" } # TODO do something with arm64 variant
+							{ GOARCH: "arm64" }
+							+ if env.version != "1.22" then {
+								# https://go.dev/doc/go1.23#arm64
+								GOARM64: ($bashbrewArch | ltrimstr("arm64") | if index(".") then . else . + ".0" end),
+							} else {} end
 						elif $bashbrewArch | startswith("arm32v") then
 							{ GOARCH: "arm", GOARM: ($bashbrewArch | ltrimstr("arm32v")) }
 						else {} end


### PR DESCRIPTION
These are (currently) unused, so this is simply added data for completeness (as evidenced by the lack of generated `Dockerfile` changes).

This will matter more if/when we implement tip/#464 (although these values are currently the default values anyhow, so this is just being completely explicit in case those defaults ever change to match the weird way `GOARM` works with a default value on *some* platforms but a detected value on others).