### PR TITLE
Support reproducible builds (except packages)

### DIFF
--- a/1.22/alpine3.19/Dockerfile
+++ b/1.22/alpine3.19/Dockerfile
@@ -12,7 +12,7 @@ ENV GOLANG_VERSION 1.22.8
 
 RUN set -eux; \
 	now="$(date '+%s')"; \
-	apk add --no-cache --virtual .fetch-deps \
+	apk add --no-cache --virtual .fetch-deps=0 \
 		ca-certificates \
 		gnupg \
 # busybox's "tar" doesn't handle directory mtime correctly, so our SOURCE_DATE_EPOCH lookup doesn't work (the mtime of "/usr/local/go" always ends up being the extraction timestamp)

--- a/1.22/alpine3.20/Dockerfile
+++ b/1.22/alpine3.20/Dockerfile
@@ -12,7 +12,7 @@ ENV GOLANG_VERSION 1.22.8
 
 RUN set -eux; \
 	now="$(date '+%s')"; \
-	apk add --no-cache --virtual .fetch-deps \
+	apk add --no-cache --virtual .fetch-deps=0 \
 		ca-certificates \
 		gnupg \
 # busybox's "tar" doesn't handle directory mtime correctly, so our SOURCE_DATE_EPOCH lookup doesn't work (the mtime of "/usr/local/go" always ends up being the extraction timestamp)

--- a/1.22/bookworm/Dockerfile
+++ b/1.22/bookworm/Dockerfile
@@ -114,7 +114,9 @@ RUN set -eux; \
 		make \
 		pkg-config \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/* ; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache
 
 ENV GOLANG_VERSION 1.22.8
 

--- a/1.22/bullseye/Dockerfile
+++ b/1.22/bullseye/Dockerfile
@@ -114,7 +114,9 @@ RUN set -eux; \
 		make \
 		pkg-config \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/* ; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache
 
 ENV GOLANG_VERSION 1.22.8
 

--- a/1.23/alpine3.19/Dockerfile
+++ b/1.23/alpine3.19/Dockerfile
@@ -12,7 +12,7 @@ ENV GOLANG_VERSION 1.23.2
 
 RUN set -eux; \
 	now="$(date '+%s')"; \
-	apk add --no-cache --virtual .fetch-deps \
+	apk add --no-cache --virtual .fetch-deps=0 \
 		ca-certificates \
 		gnupg \
 # busybox's "tar" doesn't handle directory mtime correctly, so our SOURCE_DATE_EPOCH lookup doesn't work (the mtime of "/usr/local/go" always ends up being the extraction timestamp)

--- a/1.23/alpine3.20/Dockerfile
+++ b/1.23/alpine3.20/Dockerfile
@@ -12,7 +12,7 @@ ENV GOLANG_VERSION 1.23.2
 
 RUN set -eux; \
 	now="$(date '+%s')"; \
-	apk add --no-cache --virtual .fetch-deps \
+	apk add --no-cache --virtual .fetch-deps=0 \
 		ca-certificates \
 		gnupg \
 # busybox's "tar" doesn't handle directory mtime correctly, so our SOURCE_DATE_EPOCH lookup doesn't work (the mtime of "/usr/local/go" always ends up being the extraction timestamp)

--- a/1.23/bookworm/Dockerfile
+++ b/1.23/bookworm/Dockerfile
@@ -114,7 +114,9 @@ RUN set -eux; \
 		make \
 		pkg-config \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/* ; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache
 
 ENV GOLANG_VERSION 1.23.2
 

--- a/1.23/bullseye/Dockerfile
+++ b/1.23/bullseye/Dockerfile
@@ -114,7 +114,9 @@ RUN set -eux; \
 		make \
 		pkg-config \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/* ; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache
 
 ENV GOLANG_VERSION 1.23.2
 

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -53,7 +53,7 @@ ENV GOLANG_VERSION {{ .version }}
 RUN set -eux; \
 	now="$(date '+%s')"; \
 {{ if is_alpine then ( -}}
-	apk add --no-cache --virtual .fetch-deps \
+	apk add --no-cache --virtual .fetch-deps=0 \
 		ca-certificates \
 		gnupg \
 # busybox's "tar" doesn't handle directory mtime correctly, so our SOURCE_DATE_EPOCH lookup doesn't work (the mtime of "/usr/local/go" always ends up being the extraction timestamp)
@@ -163,7 +163,9 @@ RUN set -eux; \
 		make \
 		pkg-config \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/* ; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache
 {{ ) end -}}
 
 ENV GOLANG_VERSION {{ .version }}


### PR DESCRIPTION
See:
- docker-library/official-images#16044

- - -

- For Debian, `/var/log/*` is removed as they contain timestamps

- For Debian, `/var/cache/ldconfig/aux-cache` is removed as they contain inode numbers, etc.

- For Alpine, virtual package versions are pinned to "0" to eliminate the timestamp-based version numbers that appear in `/etc/apk/world` and `/lib/apk/db/installed`

> [!NOTE]
> The following topics are NOT covered by this commit:
>
> - To reproduce file timestamps in layers, BuildKit has to be executed with
>   `--output type=<TYPE>,rewrite-timestamp=true`.
>   Needs BuildKit v0.13 or later.
>
> - To reproduce the base image by the hash, reproducers may:
>   - modify the `FROM` instruction in Dockerfile manually
>   - or, use the `CONVERT` action of source policies to replace the base image.
>     <https://github.com/moby/buildkit/blob/v0.13.2/docs/build-repro.md>
>
> - To reproduce packages, see the `RUN` instruction hook proposed in
>   moby/buildkit#4576