### PR TITLE
Add 1.24-rc1

### DIFF
--- a/1.24-rc/alpine3.20/Dockerfile
+++ b/1.24-rc/alpine3.20/Dockerfile
@@ -1,0 +1,128 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM alpine:3.20 AS build
+
+ENV PATH /usr/local/go/bin:$PATH
+
+ENV GOLANG_VERSION 1.24rc1
+
+RUN set -eux; \
+	now="$(date '+%s')"; \
+	apk add --no-cache --virtual .fetch-deps \
+		ca-certificates \
+		gnupg \
+# busybox's "tar" doesn't handle directory mtime correctly, so our SOURCE_DATE_EPOCH lookup doesn't work (the mtime of "/usr/local/go" always ends up being the extraction timestamp)
+		tar \
+	; \
+	arch="$(apk --print-arch)"; \
+	url=; \
+	case "$arch" in \
+		'x86_64') \
+			url='https://dl.google.com/go/go1.24rc1.linux-amd64.tar.gz'; \
+			sha256='706c3810c0826dd43bb6d5274c5fa4f644488274533a9bb1f9b13a0e302afcc6'; \
+			;; \
+		'armhf') \
+			url='https://dl.google.com/go/go1.24rc1.linux-armv6l.tar.gz'; \
+			sha256='8b1bd52e292626a2dae8a5d684590380bd3c6af923a7504c0fe9f9e51abbfe1e'; \
+			;; \
+		'armv7') \
+			url='https://dl.google.com/go/go1.24rc1.linux-armv6l.tar.gz'; \
+			sha256='8b1bd52e292626a2dae8a5d684590380bd3c6af923a7504c0fe9f9e51abbfe1e'; \
+			;; \
+		'aarch64') \
+			url='https://dl.google.com/go/go1.24rc1.linux-arm64.tar.gz'; \
+			sha256='febc01e97564c3851f96a778bd31f9b7631517f71e7bdf15baeb47c84d735a18'; \
+			;; \
+		'x86') \
+			url='https://dl.google.com/go/go1.24rc1.linux-386.tar.gz'; \
+			sha256='f8332a537d99504cca6d1a706a34aad74051dadcb098dc5b87de1733e24db3b7'; \
+			;; \
+		'ppc64le') \
+			url='https://dl.google.com/go/go1.24rc1.linux-ppc64le.tar.gz'; \
+			sha256='492eca7616fe51194886d5ae3a782d97559d7e8ba7e51ccb23fa1b32c79d96e9'; \
+			;; \
+		'riscv64') \
+			url='https://dl.google.com/go/go1.24rc1.linux-riscv64.tar.gz'; \
+			sha256='5cd2bc49913b0661a2f30d88fb80cd600477f66fa44b2d3d7002ce7fa7bffb91'; \
+			;; \
+		's390x') \
+			url='https://dl.google.com/go/go1.24rc1.linux-s390x.tar.gz'; \
+			sha256='13331e1c63c944b86602944945a2b87c88c002deaeea971b9930fd1d3b3e7a2c'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
+	esac; \
+	\
+	wget -O go.tgz.asc "$url.asc"; \
+	wget -O go.tgz "$url"; \
+	echo "$sha256 *go.tgz" | sha256sum -c -; \
+	\
+# https://github.com/golang/go/issues/14739#issuecomment-324767697
+	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+# https://www.google.com/linuxrepositories/
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
+# let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys '2F52 8D36 D67B 69ED F998  D857 78BD 6547 3CB3 BD13'; \
+	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" go.tgz.asc; \
+	\
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+# save the timestamp from the tarball so we can restore it for reproducibility, if necessary (see below)
+	SOURCE_DATE_EPOCH="$(stat -c '%Y' /usr/local/go)"; \
+	export SOURCE_DATE_EPOCH; \
+	touchy="$(date -d "@$SOURCE_DATE_EPOCH" '+%Y%m%d%H%M.%S')"; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
+# sanity check (detected value should be older than our wall clock)
+	[ "$SOURCE_DATE_EPOCH" -lt "$now" ]; \
+	\
+	if [ "$arch" = 'armv7' ]; then \
+		[ -s /usr/local/go/go.env ]; \
+		before="$(go env GOARM)"; [ "$before" != '7' ]; \
+		{ \
+			echo; \
+			echo '# https://github.com/docker-library/golang/issues/494'; \
+			echo 'GOARM=7'; \
+		} >> /usr/local/go/go.env; \
+		after="$(go env GOARM)"; [ "$after" = '7' ]; \
+# (re-)clamp timestamp for reproducibility (allows "COPY --link" to be more clever/useful)
+		touch -t "$touchy" /usr/local/go/go.env /usr/local/go; \
+	fi; \
+	\
+# ideally at this point, we would just "COPY --link ... /usr/local/go/ /usr/local/go/" but BuildKit insists on creating the parent directories (perhaps related to https://github.com/opencontainers/image-spec/pull/970), and does so with unreproducible timestamps, so we instead create a whole new "directory tree" that we can "COPY --link" to accomplish what we want
+	mkdir /target /target/usr /target/usr/local; \
+	mv -vT /usr/local/go /target/usr/local/go; \
+	ln -svfT /target/usr/local/go /usr/local/go; \
+	touch -t "$touchy" /target/usr/local /target/usr /target; \
+	\
+	apk del --no-network .fetch-deps; \
+	\
+# smoke test
+	go version; \
+# make sure our reproducibile timestamp is probably still correct (best-effort inline reproducibility test)
+	epoch="$(stat -c '%Y' /target/usr/local/go)"; \
+	[ "$SOURCE_DATE_EPOCH" = "$epoch" ]; \
+	find /target -newer /target/usr/local/go -exec sh -c 'ls -ld "$@" && exit "$#"' -- '{}' +
+
+FROM alpine:3.20
+
+RUN apk add --no-cache ca-certificates
+
+ENV GOLANG_VERSION 1.24rc1
+
+# don't auto-upgrade the gotoolchain
+# https://github.com/docker-library/golang/issues/472
+ENV GOTOOLCHAIN=local
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+# (see notes above about "COPY --link")
+COPY --from=build --link /target/ /
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
+WORKDIR $GOPATH

--- a/1.24-rc/alpine3.21/Dockerfile
+++ b/1.24-rc/alpine3.21/Dockerfile
@@ -1,0 +1,128 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM alpine:3.21 AS build
+
+ENV PATH /usr/local/go/bin:$PATH
+
+ENV GOLANG_VERSION 1.24rc1
+
+RUN set -eux; \
+	now="$(date '+%s')"; \
+	apk add --no-cache --virtual .fetch-deps \
+		ca-certificates \
+		gnupg \
+# busybox's "tar" doesn't handle directory mtime correctly, so our SOURCE_DATE_EPOCH lookup doesn't work (the mtime of "/usr/local/go" always ends up being the extraction timestamp)
+		tar \
+	; \
+	arch="$(apk --print-arch)"; \
+	url=; \
+	case "$arch" in \
+		'x86_64') \
+			url='https://dl.google.com/go/go1.24rc1.linux-amd64.tar.gz'; \
+			sha256='706c3810c0826dd43bb6d5274c5fa4f644488274533a9bb1f9b13a0e302afcc6'; \
+			;; \
+		'armhf') \
+			url='https://dl.google.com/go/go1.24rc1.linux-armv6l.tar.gz'; \
+			sha256='8b1bd52e292626a2dae8a5d684590380bd3c6af923a7504c0fe9f9e51abbfe1e'; \
+			;; \
+		'armv7') \
+			url='https://dl.google.com/go/go1.24rc1.linux-armv6l.tar.gz'; \
+			sha256='8b1bd52e292626a2dae8a5d684590380bd3c6af923a7504c0fe9f9e51abbfe1e'; \
+			;; \
+		'aarch64') \
+			url='https://dl.google.com/go/go1.24rc1.linux-arm64.tar.gz'; \
+			sha256='febc01e97564c3851f96a778bd31f9b7631517f71e7bdf15baeb47c84d735a18'; \
+			;; \
+		'x86') \
+			url='https://dl.google.com/go/go1.24rc1.linux-386.tar.gz'; \
+			sha256='f8332a537d99504cca6d1a706a34aad74051dadcb098dc5b87de1733e24db3b7'; \
+			;; \
+		'ppc64le') \
+			url='https://dl.google.com/go/go1.24rc1.linux-ppc64le.tar.gz'; \
+			sha256='492eca7616fe51194886d5ae3a782d97559d7e8ba7e51ccb23fa1b32c79d96e9'; \
+			;; \
+		'riscv64') \
+			url='https://dl.google.com/go/go1.24rc1.linux-riscv64.tar.gz'; \
+			sha256='5cd2bc49913b0661a2f30d88fb80cd600477f66fa44b2d3d7002ce7fa7bffb91'; \
+			;; \
+		's390x') \
+			url='https://dl.google.com/go/go1.24rc1.linux-s390x.tar.gz'; \
+			sha256='13331e1c63c944b86602944945a2b87c88c002deaeea971b9930fd1d3b3e7a2c'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
+	esac; \
+	\
+	wget -O go.tgz.asc "$url.asc"; \
+	wget -O go.tgz "$url"; \
+	echo "$sha256 *go.tgz" | sha256sum -c -; \
+	\
+# https://github.com/golang/go/issues/14739#issuecomment-324767697
+	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+# https://www.google.com/linuxrepositories/
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
+# let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys '2F52 8D36 D67B 69ED F998  D857 78BD 6547 3CB3 BD13'; \
+	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" go.tgz.asc; \
+	\
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+# save the timestamp from the tarball so we can restore it for reproducibility, if necessary (see below)
+	SOURCE_DATE_EPOCH="$(stat -c '%Y' /usr/local/go)"; \
+	export SOURCE_DATE_EPOCH; \
+	touchy="$(date -d "@$SOURCE_DATE_EPOCH" '+%Y%m%d%H%M.%S')"; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
+# sanity check (detected value should be older than our wall clock)
+	[ "$SOURCE_DATE_EPOCH" -lt "$now" ]; \
+	\
+	if [ "$arch" = 'armv7' ]; then \
+		[ -s /usr/local/go/go.env ]; \
+		before="$(go env GOARM)"; [ "$before" != '7' ]; \
+		{ \
+			echo; \
+			echo '# https://github.com/docker-library/golang/issues/494'; \
+			echo 'GOARM=7'; \
+		} >> /usr/local/go/go.env; \
+		after="$(go env GOARM)"; [ "$after" = '7' ]; \
+# (re-)clamp timestamp for reproducibility (allows "COPY --link" to be more clever/useful)
+		touch -t "$touchy" /usr/local/go/go.env /usr/local/go; \
+	fi; \
+	\
+# ideally at this point, we would just "COPY --link ... /usr/local/go/ /usr/local/go/" but BuildKit insists on creating the parent directories (perhaps related to https://github.com/opencontainers/image-spec/pull/970), and does so with unreproducible timestamps, so we instead create a whole new "directory tree" that we can "COPY --link" to accomplish what we want
+	mkdir /target /target/usr /target/usr/local; \
+	mv -vT /usr/local/go /target/usr/local/go; \
+	ln -svfT /target/usr/local/go /usr/local/go; \
+	touch -t "$touchy" /target/usr/local /target/usr /target; \
+	\
+	apk del --no-network .fetch-deps; \
+	\
+# smoke test
+	go version; \
+# make sure our reproducibile timestamp is probably still correct (best-effort inline reproducibility test)
+	epoch="$(stat -c '%Y' /target/usr/local/go)"; \
+	[ "$SOURCE_DATE_EPOCH" = "$epoch" ]; \
+	find /target -newer /target/usr/local/go -exec sh -c 'ls -ld "$@" && exit "$#"' -- '{}' +
+
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates
+
+ENV GOLANG_VERSION 1.24rc1
+
+# don't auto-upgrade the gotoolchain
+# https://github.com/docker-library/golang/issues/472
+ENV GOTOOLCHAIN=local
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+# (see notes above about "COPY --link")
+COPY --from=build --link /target/ /
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
+WORKDIR $GOPATH

--- a/1.24-rc/bookworm/Dockerfile
+++ b/1.24-rc/bookworm/Dockerfile
@@ -1,0 +1,130 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM buildpack-deps:bookworm-scm AS build
+
+ENV PATH /usr/local/go/bin:$PATH
+
+ENV GOLANG_VERSION 1.24rc1
+
+RUN set -eux; \
+	now="$(date '+%s')"; \
+	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
+	url=; \
+	case "$arch" in \
+		'amd64') \
+			url='https://dl.google.com/go/go1.24rc1.linux-amd64.tar.gz'; \
+			sha256='706c3810c0826dd43bb6d5274c5fa4f644488274533a9bb1f9b13a0e302afcc6'; \
+			;; \
+		'armhf') \
+			url='https://dl.google.com/go/go1.24rc1.linux-armv6l.tar.gz'; \
+			sha256='8b1bd52e292626a2dae8a5d684590380bd3c6af923a7504c0fe9f9e51abbfe1e'; \
+			;; \
+		'arm64') \
+			url='https://dl.google.com/go/go1.24rc1.linux-arm64.tar.gz'; \
+			sha256='febc01e97564c3851f96a778bd31f9b7631517f71e7bdf15baeb47c84d735a18'; \
+			;; \
+		'i386') \
+			url='https://dl.google.com/go/go1.24rc1.linux-386.tar.gz'; \
+			sha256='f8332a537d99504cca6d1a706a34aad74051dadcb098dc5b87de1733e24db3b7'; \
+			;; \
+		'mips64el') \
+			url='https://dl.google.com/go/go1.24rc1.linux-mips64le.tar.gz'; \
+			sha256='3841c8c24969a4151d3aa2cc4822a5355779f7136fd7d3d096a833da9dd4dbdf'; \
+			;; \
+		'ppc64el') \
+			url='https://dl.google.com/go/go1.24rc1.linux-ppc64le.tar.gz'; \
+			sha256='492eca7616fe51194886d5ae3a782d97559d7e8ba7e51ccb23fa1b32c79d96e9'; \
+			;; \
+		'riscv64') \
+			url='https://dl.google.com/go/go1.24rc1.linux-riscv64.tar.gz'; \
+			sha256='5cd2bc49913b0661a2f30d88fb80cd600477f66fa44b2d3d7002ce7fa7bffb91'; \
+			;; \
+		's390x') \
+			url='https://dl.google.com/go/go1.24rc1.linux-s390x.tar.gz'; \
+			sha256='13331e1c63c944b86602944945a2b87c88c002deaeea971b9930fd1d3b3e7a2c'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
+	esac; \
+	\
+	wget -O go.tgz.asc "$url.asc"; \
+	wget -O go.tgz "$url" --progress=dot:giga; \
+	echo "$sha256 *go.tgz" | sha256sum -c -; \
+	\
+# https://github.com/golang/go/issues/14739#issuecomment-324767697
+	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+# https://www.google.com/linuxrepositories/
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
+# let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys '2F52 8D36 D67B 69ED F998  D857 78BD 6547 3CB3 BD13'; \
+	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" go.tgz.asc; \
+	\
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+# save the timestamp from the tarball so we can restore it for reproducibility, if necessary (see below)
+	SOURCE_DATE_EPOCH="$(stat -c '%Y' /usr/local/go)"; \
+	export SOURCE_DATE_EPOCH; \
+	touchy="$(date -d "@$SOURCE_DATE_EPOCH" '+%Y%m%d%H%M.%S')"; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
+# sanity check (detected value should be older than our wall clock)
+	[ "$SOURCE_DATE_EPOCH" -lt "$now" ]; \
+	\
+	if [ "$arch" = 'armhf' ]; then \
+		[ -s /usr/local/go/go.env ]; \
+		before="$(go env GOARM)"; [ "$before" != '7' ]; \
+		{ \
+			echo; \
+			echo '# https://github.com/docker-library/golang/issues/494'; \
+			echo 'GOARM=7'; \
+		} >> /usr/local/go/go.env; \
+		after="$(go env GOARM)"; [ "$after" = '7' ]; \
+# (re-)clamp timestamp for reproducibility (allows "COPY --link" to be more clever/useful)
+		touch -t "$touchy" /usr/local/go/go.env /usr/local/go; \
+	fi; \
+	\
+# ideally at this point, we would just "COPY --link ... /usr/local/go/ /usr/local/go/" but BuildKit insists on creating the parent directories (perhaps related to https://github.com/opencontainers/image-spec/pull/970), and does so with unreproducible timestamps, so we instead create a whole new "directory tree" that we can "COPY --link" to accomplish what we want
+	mkdir /target /target/usr /target/usr/local; \
+	mv -vT /usr/local/go /target/usr/local/go; \
+	ln -svfT /target/usr/local/go /usr/local/go; \
+	touch -t "$touchy" /target/usr/local /target/usr /target; \
+	\
+# smoke test
+	go version; \
+# make sure our reproducibile timestamp is probably still correct (best-effort inline reproducibility test)
+	epoch="$(stat -c '%Y' /target/usr/local/go)"; \
+	[ "$SOURCE_DATE_EPOCH" = "$epoch" ]; \
+	find /target -newer /target/usr/local/go -exec sh -c 'ls -ld "$@" && exit "$#"' -- '{}' +
+
+FROM buildpack-deps:bookworm-scm
+
+# install cgo-related dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		g++ \
+		gcc \
+		libc6-dev \
+		make \
+		pkg-config \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+ENV GOLANG_VERSION 1.24rc1
+
+# don't auto-upgrade the gotoolchain
+# https://github.com/docker-library/golang/issues/472
+ENV GOTOOLCHAIN=local
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+# (see notes above about "COPY --link")
+COPY --from=build --link /target/ /
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
+WORKDIR $GOPATH

--- a/1.24-rc/bullseye/Dockerfile
+++ b/1.24-rc/bullseye/Dockerfile
@@ -1,0 +1,130 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM buildpack-deps:bullseye-scm AS build
+
+ENV PATH /usr/local/go/bin:$PATH
+
+ENV GOLANG_VERSION 1.24rc1
+
+RUN set -eux; \
+	now="$(date '+%s')"; \
+	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
+	url=; \
+	case "$arch" in \
+		'amd64') \
+			url='https://dl.google.com/go/go1.24rc1.linux-amd64.tar.gz'; \
+			sha256='706c3810c0826dd43bb6d5274c5fa4f644488274533a9bb1f9b13a0e302afcc6'; \
+			;; \
+		'armhf') \
+			url='https://dl.google.com/go/go1.24rc1.linux-armv6l.tar.gz'; \
+			sha256='8b1bd52e292626a2dae8a5d684590380bd3c6af923a7504c0fe9f9e51abbfe1e'; \
+			;; \
+		'arm64') \
+			url='https://dl.google.com/go/go1.24rc1.linux-arm64.tar.gz'; \
+			sha256='febc01e97564c3851f96a778bd31f9b7631517f71e7bdf15baeb47c84d735a18'; \
+			;; \
+		'i386') \
+			url='https://dl.google.com/go/go1.24rc1.linux-386.tar.gz'; \
+			sha256='f8332a537d99504cca6d1a706a34aad74051dadcb098dc5b87de1733e24db3b7'; \
+			;; \
+		'mips64el') \
+			url='https://dl.google.com/go/go1.24rc1.linux-mips64le.tar.gz'; \
+			sha256='3841c8c24969a4151d3aa2cc4822a5355779f7136fd7d3d096a833da9dd4dbdf'; \
+			;; \
+		'ppc64el') \
+			url='https://dl.google.com/go/go1.24rc1.linux-ppc64le.tar.gz'; \
+			sha256='492eca7616fe51194886d5ae3a782d97559d7e8ba7e51ccb23fa1b32c79d96e9'; \
+			;; \
+		'riscv64') \
+			url='https://dl.google.com/go/go1.24rc1.linux-riscv64.tar.gz'; \
+			sha256='5cd2bc49913b0661a2f30d88fb80cd600477f66fa44b2d3d7002ce7fa7bffb91'; \
+			;; \
+		's390x') \
+			url='https://dl.google.com/go/go1.24rc1.linux-s390x.tar.gz'; \
+			sha256='13331e1c63c944b86602944945a2b87c88c002deaeea971b9930fd1d3b3e7a2c'; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
+	esac; \
+	\
+	wget -O go.tgz.asc "$url.asc"; \
+	wget -O go.tgz "$url" --progress=dot:giga; \
+	echo "$sha256 *go.tgz" | sha256sum -c -; \
+	\
+# https://github.com/golang/go/issues/14739#issuecomment-324767697
+	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+# https://www.google.com/linuxrepositories/
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 'EB4C 1BFD 4F04 2F6D DDCC  EC91 7721 F63B D38B 4796'; \
+# let's also fetch the specific subkey of that key explicitly that we expect "go.tgz.asc" to be signed by, just to make sure we definitely have it
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys '2F52 8D36 D67B 69ED F998  D857 78BD 6547 3CB3 BD13'; \
+	gpg --batch --verify go.tgz.asc go.tgz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" go.tgz.asc; \
+	\
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+# save the timestamp from the tarball so we can restore it for reproducibility, if necessary (see below)
+	SOURCE_DATE_EPOCH="$(stat -c '%Y' /usr/local/go)"; \
+	export SOURCE_DATE_EPOCH; \
+	touchy="$(date -d "@$SOURCE_DATE_EPOCH" '+%Y%m%d%H%M.%S')"; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
+# sanity check (detected value should be older than our wall clock)
+	[ "$SOURCE_DATE_EPOCH" -lt "$now" ]; \
+	\
+	if [ "$arch" = 'armhf' ]; then \
+		[ -s /usr/local/go/go.env ]; \
+		before="$(go env GOARM)"; [ "$before" != '7' ]; \
+		{ \
+			echo; \
+			echo '# https://github.com/docker-library/golang/issues/494'; \
+			echo 'GOARM=7'; \
+		} >> /usr/local/go/go.env; \
+		after="$(go env GOARM)"; [ "$after" = '7' ]; \
+# (re-)clamp timestamp for reproducibility (allows "COPY --link" to be more clever/useful)
+		touch -t "$touchy" /usr/local/go/go.env /usr/local/go; \
+	fi; \
+	\
+# ideally at this point, we would just "COPY --link ... /usr/local/go/ /usr/local/go/" but BuildKit insists on creating the parent directories (perhaps related to https://github.com/opencontainers/image-spec/pull/970), and does so with unreproducible timestamps, so we instead create a whole new "directory tree" that we can "COPY --link" to accomplish what we want
+	mkdir /target /target/usr /target/usr/local; \
+	mv -vT /usr/local/go /target/usr/local/go; \
+	ln -svfT /target/usr/local/go /usr/local/go; \
+	touch -t "$touchy" /target/usr/local /target/usr /target; \
+	\
+# smoke test
+	go version; \
+# make sure our reproducibile timestamp is probably still correct (best-effort inline reproducibility test)
+	epoch="$(stat -c '%Y' /target/usr/local/go)"; \
+	[ "$SOURCE_DATE_EPOCH" = "$epoch" ]; \
+	find /target -newer /target/usr/local/go -exec sh -c 'ls -ld "$@" && exit "$#"' -- '{}' +
+
+FROM buildpack-deps:bullseye-scm
+
+# install cgo-related dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		g++ \
+		gcc \
+		libc6-dev \
+		make \
+		pkg-config \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+ENV GOLANG_VERSION 1.24rc1
+
+# don't auto-upgrade the gotoolchain
+# https://github.com/docker-library/golang/issues/472
+ENV GOTOOLCHAIN=local
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+# (see notes above about "COPY --link")
+COPY --from=build --link /target/ /
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
+WORKDIR $GOPATH

--- a/1.24-rc/windows/nanoserver-1809/Dockerfile
+++ b/1.24-rc/windows/nanoserver-1809/Dockerfile
@@ -1,0 +1,30 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+SHELL ["cmd", "/S", "/C"]
+
+# no Git installed (intentionally)
+#  -- Nano Server is "Windows Slim"
+
+# for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
+ENV GOPATH C:\\go
+# HOWEVER, please note that it is the Go upstream intention to remove GOPATH support entirely: https://blog.golang.org/go116-module-changes
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+USER ContainerAdministrator
+RUN setx /m PATH "%GOPATH%\bin;C:\Program Files\Go\bin;%PATH%"
+USER ContainerUser
+# doing this first to share cache across versions more aggressively
+
+ENV GOLANG_VERSION 1.24rc1
+
+# Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
+COPY --from=golang:1.24rc1-windowsservercore-1809 ["C:\\\\Program Files\\\\Go","C:\\\\Program Files\\\\Go"]
+RUN go version
+
+WORKDIR $GOPATH

--- a/1.24-rc/windows/nanoserver-ltsc2022/Dockerfile
+++ b/1.24-rc/windows/nanoserver-ltsc2022/Dockerfile
@@ -1,0 +1,30 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
+
+SHELL ["cmd", "/S", "/C"]
+
+# no Git installed (intentionally)
+#  -- Nano Server is "Windows Slim"
+
+# for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
+ENV GOPATH C:\\go
+# HOWEVER, please note that it is the Go upstream intention to remove GOPATH support entirely: https://blog.golang.org/go116-module-changes
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+USER ContainerAdministrator
+RUN setx /m PATH "%GOPATH%\bin;C:\Program Files\Go\bin;%PATH%"
+USER ContainerUser
+# doing this first to share cache across versions more aggressively
+
+ENV GOLANG_VERSION 1.24rc1
+
+# Docker's Windows path parsing is absolutely *cursed*; please just trust me on this one -Tianon
+COPY --from=golang:1.24rc1-windowsservercore-ltsc2022 ["C:\\\\Program Files\\\\Go","C:\\\\Program Files\\\\Go"]
+RUN go version
+
+WORKDIR $GOPATH

--- a/1.24-rc/windows/windowsservercore-1809/Dockerfile
+++ b/1.24-rc/windows/windowsservercore-1809/Dockerfile
@@ -1,0 +1,84 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/servercore:1809
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# install MinGit (especially for "go get")
+# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
+# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
+# "It currently requires only ~45MB on disk."
+ENV GIT_VERSION 2.23.0
+ENV GIT_TAG v${GIT_VERSION}.windows.1
+ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${GIT_TAG}/MinGit-${GIT_VERSION}-64-bit.zip
+ENV GIT_DOWNLOAD_SHA256 8f65208f92c0b4c3ae4c0cf02d4b5f6791d539cd1a07b2df62b7116467724735
+# steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
+RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:GIT_DOWNLOAD_URL -OutFile 'git.zip'; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_DOWNLOAD_SHA256); \
+	if ((Get-FileHash git.zip -Algorithm sha256).Hash -ne $env:GIT_DOWNLOAD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive -Path git.zip -DestinationPath C:\git\.; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item git.zip -Force; \
+	\
+	Write-Host 'Updating PATH ...'; \
+	$env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ("git version") ...'; \
+	git version; \
+	\
+	Write-Host 'Complete.';
+
+# for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
+ENV GOPATH C:\\go
+# HOWEVER, please note that it is the Go upstream intention to remove GOPATH support entirely: https://blog.golang.org/go116-module-changes
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
+# doing this first to share cache across versions more aggressively
+
+ENV GOLANG_VERSION 1.24rc1
+
+RUN $url = 'https://dl.google.com/go/go1.24rc1.windows-amd64.zip'; \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
+	\
+	$sha256 = '82690f356b18800c9c132a7010b8e9bf50977f408993f3d30f7b81a7c5a03c4d'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
+	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive go.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Moving ...'; \
+	Move-Item -Path C:\go -Destination 'C:\Program Files\Go'; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
+	\
+	Write-Host 'Complete.';
+
+WORKDIR $GOPATH

--- a/1.24-rc/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/1.24-rc/windows/windowsservercore-ltsc2022/Dockerfile
@@ -1,0 +1,84 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# install MinGit (especially for "go get")
+# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
+# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
+# "It currently requires only ~45MB on disk."
+ENV GIT_VERSION 2.23.0
+ENV GIT_TAG v${GIT_VERSION}.windows.1
+ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${GIT_TAG}/MinGit-${GIT_VERSION}-64-bit.zip
+ENV GIT_DOWNLOAD_SHA256 8f65208f92c0b4c3ae4c0cf02d4b5f6791d539cd1a07b2df62b7116467724735
+# steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
+RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:GIT_DOWNLOAD_URL -OutFile 'git.zip'; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:GIT_DOWNLOAD_SHA256); \
+	if ((Get-FileHash git.zip -Algorithm sha256).Hash -ne $env:GIT_DOWNLOAD_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive -Path git.zip -DestinationPath C:\git\.; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item git.zip -Force; \
+	\
+	Write-Host 'Updating PATH ...'; \
+	$env:PATH = 'C:\git\cmd;C:\git\mingw64\bin;C:\git\usr\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ("git version") ...'; \
+	git version; \
+	\
+	Write-Host 'Complete.';
+
+# for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
+ENV GOPATH C:\\go
+# HOWEVER, please note that it is the Go upstream intention to remove GOPATH support entirely: https://blog.golang.org/go116-module-changes
+
+# PATH isn't actually set in the Docker image, so we have to set it from within the container
+RUN $newPath = ('{0}\bin;C:\Program Files\Go\bin;{1}' -f $env:GOPATH, $env:PATH); \
+	Write-Host ('Updating PATH: {0}' -f $newPath); \
+	[Environment]::SetEnvironmentVariable('PATH', $newPath, [EnvironmentVariableTarget]::Machine);
+# doing this first to share cache across versions more aggressively
+
+ENV GOLANG_VERSION 1.24rc1
+
+RUN $url = 'https://dl.google.com/go/go1.24rc1.windows-amd64.zip'; \
+	Write-Host ('Downloading {0} ...' -f $url); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
+	\
+	$sha256 = '82690f356b18800c9c132a7010b8e9bf50977f408993f3d30f7b81a7c5a03c4d'; \
+	Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
+	if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Expanding ...'; \
+	Expand-Archive go.zip -DestinationPath C:\; \
+	\
+	Write-Host 'Moving ...'; \
+	Move-Item -Path C:\go -Destination 'C:\Program Files\Go'; \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item go.zip -Force; \
+	\
+	Write-Host 'Verifying install ("go version") ...'; \
+	go version; \
+	\
+	Write-Host 'Complete.';
+
+WORKDIR $GOPATH

--- a/versions.json
+++ b/versions.json
@@ -811,5 +811,408 @@
       "windows/nanoserver-ltsc2022",
       "windows/nanoserver-1809"
     ]
+  },
+  "1.24-rc": {
+    "version": "1.24rc1",
+    "arches": {
+      "aix-ppc64": {
+        "url": "https://dl.google.com/go/go1.24rc1.aix-ppc64.tar.gz",
+        "sha256": "77b63813612ffae947ef7446c392ca3bac203f8967d25cb7f7716a5e547806d4",
+        "env": {
+          "GOOS": "aix",
+          "GOARCH": "ppc64"
+        },
+        "supported": false
+      },
+      "amd64": {
+        "url": "https://dl.google.com/go/go1.24rc1.linux-amd64.tar.gz",
+        "sha256": "706c3810c0826dd43bb6d5274c5fa4f644488274533a9bb1f9b13a0e302afcc6",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "amd64",
+          "GOAMD64": "v1"
+        },
+        "supported": true
+      },
+      "arm32v5": {
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "arm",
+          "GOARM": "5"
+        },
+        "supported": false
+      },
+      "arm32v6": {
+        "url": "https://dl.google.com/go/go1.24rc1.linux-armv6l.tar.gz",
+        "sha256": "8b1bd52e292626a2dae8a5d684590380bd3c6af923a7504c0fe9f9e51abbfe1e",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "arm",
+          "GOARM": "6"
+        },
+        "supported": true
+      },
+      "arm32v7": {
+        "url": "https://dl.google.com/go/go1.24rc1.linux-armv6l.tar.gz",
+        "sha256": "8b1bd52e292626a2dae8a5d684590380bd3c6af923a7504c0fe9f9e51abbfe1e",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "arm",
+          "GOARM": "7"
+        },
+        "supported": true
+      },
+      "arm64v8": {
+        "url": "https://dl.google.com/go/go1.24rc1.linux-arm64.tar.gz",
+        "sha256": "febc01e97564c3851f96a778bd31f9b7631517f71e7bdf15baeb47c84d735a18",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "arm64",
+          "GOARM64": "v8.0"
+        },
+        "supported": true
+      },
+      "darwin-amd64": {
+        "url": "https://dl.google.com/go/go1.24rc1.darwin-amd64.tar.gz",
+        "sha256": "0f0895cbaf4e0c0ea0c4c2ffa2f428b0af0dfc39b64ad9f34c7c4de1be39ee55",
+        "env": {
+          "GOOS": "darwin",
+          "GOARCH": "amd64"
+        },
+        "supported": false
+      },
+      "darwin-arm64v8": {
+        "url": "https://dl.google.com/go/go1.24rc1.darwin-arm64.tar.gz",
+        "sha256": "457a34b8228db747404b71e9a9789623c808256a862ee5acb5dd9d002d819938",
+        "env": {
+          "GOOS": "darwin",
+          "GOARCH": "arm64"
+        },
+        "supported": false
+      },
+      "dragonfly-amd64": {
+        "url": "https://dl.google.com/go/go1.24rc1.dragonfly-amd64.tar.gz",
+        "sha256": "584b2bcbba8d40ff0ecf03623b64cd70418846d17188af265f10674b24d1bdc3",
+        "env": {
+          "GOOS": "dragonfly",
+          "GOARCH": "amd64"
+        },
+        "supported": false
+      },
+      "freebsd-amd64": {
+        "url": "https://dl.google.com/go/go1.24rc1.freebsd-amd64.tar.gz",
+        "sha256": "74c162d66208a98a485d3c078280875c687119d3b5e4e1a75222c1c67018cf26",
+        "env": {
+          "GOOS": "freebsd",
+          "GOARCH": "amd64"
+        },
+        "supported": false
+      },
+      "freebsd-arm": {
+        "url": "https://dl.google.com/go/go1.24rc1.freebsd-arm.tar.gz",
+        "sha256": "919ffc52164ea02ca4bd67bdd852b1b60668d8061f018ff3ff6145b3d8b840a4",
+        "env": {
+          "GOOS": "freebsd",
+          "GOARCH": "arm"
+        },
+        "supported": false
+      },
+      "freebsd-arm64v8": {
+        "url": "https://dl.google.com/go/go1.24rc1.freebsd-arm64.tar.gz",
+        "sha256": "1aa6e36d30a735b077737eb2648b60fc9bf2ef2bbf1f799206a2728c23b94d0f",
+        "env": {
+          "GOOS": "freebsd",
+          "GOARCH": "arm64"
+        },
+        "supported": false
+      },
+      "freebsd-i386": {
+        "url": "https://dl.google.com/go/go1.24rc1.freebsd-386.tar.gz",
+        "sha256": "66b9c553cbc3ea76417c95dee81950f16d10811ea371f4b8c473bef44ba4eb01",
+        "env": {
+          "GOOS": "freebsd",
+          "GOARCH": "386"
+        },
+        "supported": false
+      },
+      "freebsd-riscv64": {
+        "url": "https://dl.google.com/go/go1.24rc1.freebsd-riscv64.tar.gz",
+        "sha256": "4d921ac6852c440572062674b510d05db0078dbfafa4e96093bbe3df8494fe05",
+        "env": {
+          "GOOS": "freebsd",
+          "GOARCH": "riscv64"
+        },
+        "supported": false
+      },
+      "i386": {
+        "url": "https://dl.google.com/go/go1.24rc1.linux-386.tar.gz",
+        "sha256": "f8332a537d99504cca6d1a706a34aad74051dadcb098dc5b87de1733e24db3b7",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "386",
+          "GO386": "softfloat"
+        },
+        "supported": true
+      },
+      "illumos-amd64": {
+        "url": "https://dl.google.com/go/go1.24rc1.illumos-amd64.tar.gz",
+        "sha256": "0a7fd82f3c8e6dc49fdce13081678c1633406bdf76fea6045c358dc544e55490",
+        "env": {
+          "GOOS": "illumos",
+          "GOARCH": "amd64"
+        },
+        "supported": false
+      },
+      "loong64": {
+        "url": "https://dl.google.com/go/go1.24rc1.linux-loong64.tar.gz",
+        "sha256": "54631f57f99e7807324cbe9e3a4133e41edbcf404f885993e5375a7049f4bb5e",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "loong64"
+        },
+        "supported": false
+      },
+      "mips": {
+        "url": "https://dl.google.com/go/go1.24rc1.linux-mips.tar.gz",
+        "sha256": "db9d022394aca7a03eb747a6224978281c4f5d065cac46a166bdb06cc7e86272",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "mips"
+        },
+        "supported": false
+      },
+      "mips64": {
+        "url": "https://dl.google.com/go/go1.24rc1.linux-mips64.tar.gz",
+        "sha256": "9a6fcd39f2af5e1015b62bde6f129d2e3e622e1702f4044d5726d49fb2bb5488",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "mips64"
+        },
+        "supported": false
+      },
+      "mips64le": {
+        "url": "https://dl.google.com/go/go1.24rc1.linux-mips64le.tar.gz",
+        "sha256": "3841c8c24969a4151d3aa2cc4822a5355779f7136fd7d3d096a833da9dd4dbdf",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "mips64le"
+        },
+        "supported": true
+      },
+      "mipsle": {
+        "url": "https://dl.google.com/go/go1.24rc1.linux-mipsle.tar.gz",
+        "sha256": "41b4c2d85a72e9dc1efad65cc90087fec4a4ade5a1029a2e1da39758507a6ff1",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "mipsle"
+        },
+        "supported": false
+      },
+      "netbsd-amd64": {
+        "url": "https://dl.google.com/go/go1.24rc1.netbsd-amd64.tar.gz",
+        "sha256": "e048ff0548646bbdb85288ba448addef96938d0353a0d79013d34d79c5a917e5",
+        "env": {
+          "GOOS": "netbsd",
+          "GOARCH": "amd64"
+        },
+        "supported": false
+      },
+      "netbsd-arm": {
+        "url": "https://dl.google.com/go/go1.24rc1.netbsd-arm.tar.gz",
+        "sha256": "41dff7d095e898534639e781d92106844c93e00895c418cc0203360ffce23950",
+        "env": {
+          "GOOS": "netbsd",
+          "GOARCH": "arm"
+        },
+        "supported": false
+      },
+      "netbsd-arm64v8": {
+        "url": "https://dl.google.com/go/go1.24rc1.netbsd-arm64.tar.gz",
+        "sha256": "2761e729ab19fe3099409ef8667a7966ba16ec0b8433bd4429d74388dd57a529",
+        "env": {
+          "GOOS": "netbsd",
+          "GOARCH": "arm64"
+        },
+        "supported": false
+      },
+      "netbsd-i386": {
+        "url": "https://dl.google.com/go/go1.24rc1.netbsd-386.tar.gz",
+        "sha256": "84a9268efaf95ab50852b4f39f39cc73b4911a609ff6056aca8709bd52f1faf2",
+        "env": {
+          "GOOS": "netbsd",
+          "GOARCH": "386"
+        },
+        "supported": false
+      },
+      "openbsd-amd64": {
+        "url": "https://dl.google.com/go/go1.24rc1.openbsd-amd64.tar.gz",
+        "sha256": "2f5e9f223ee3773e29ff0aa4b5abe2948c9a4bb782c7d3d2f8a1e1e886c54bfd",
+        "env": {
+          "GOOS": "openbsd",
+          "GOARCH": "amd64"
+        },
+        "supported": false
+      },
+      "openbsd-arm": {
+        "url": "https://dl.google.com/go/go1.24rc1.openbsd-arm.tar.gz",
+        "sha256": "a89f1600e7598128432b0df70b9474d5c01f11b448c22a88296f05aad13ce0ef",
+        "env": {
+          "GOOS": "openbsd",
+          "GOARCH": "arm"
+        },
+        "supported": false
+      },
+      "openbsd-arm64v8": {
+        "url": "https://dl.google.com/go/go1.24rc1.openbsd-arm64.tar.gz",
+        "sha256": "c3b7472d0934dce86052027c91850af5eba38013152b59f7e6ace2d780f0fc03",
+        "env": {
+          "GOOS": "openbsd",
+          "GOARCH": "arm64"
+        },
+        "supported": false
+      },
+      "openbsd-i386": {
+        "url": "https://dl.google.com/go/go1.24rc1.openbsd-386.tar.gz",
+        "sha256": "f0dca9d1a9f8c0559389e4c5638c2e59b56702644211ec34fe88430e21db9925",
+        "env": {
+          "GOOS": "openbsd",
+          "GOARCH": "386"
+        },
+        "supported": false
+      },
+      "openbsd-ppc64": {
+        "url": "https://dl.google.com/go/go1.24rc1.openbsd-ppc64.tar.gz",
+        "sha256": "e547f8a2e0c78121721ca0cceed22e81d129f05520ff4c9c46e9b2304960450a",
+        "env": {
+          "GOOS": "openbsd",
+          "GOARCH": "ppc64"
+        },
+        "supported": false
+      },
+      "openbsd-riscv64": {
+        "url": "https://dl.google.com/go/go1.24rc1.openbsd-riscv64.tar.gz",
+        "sha256": "068553f706ca19850f10e5c66436fa8ccdb615497fc692c8c2439ebdcec71012",
+        "env": {
+          "GOOS": "openbsd",
+          "GOARCH": "riscv64"
+        },
+        "supported": false
+      },
+      "plan9-amd64": {
+        "url": "https://dl.google.com/go/go1.24rc1.plan9-amd64.tar.gz",
+        "sha256": "28313d92c5a6e9524405d535bc7cae797526e65d3ca496e71652b086952a8053",
+        "env": {
+          "GOOS": "plan9",
+          "GOARCH": "amd64"
+        },
+        "supported": false
+      },
+      "plan9-arm": {
+        "url": "https://dl.google.com/go/go1.24rc1.plan9-arm.tar.gz",
+        "sha256": "0392cd503e1901911db6a193ac50b8881d104847d57be63b509537273b53e1a9",
+        "env": {
+          "GOOS": "plan9",
+          "GOARCH": "arm"
+        },
+        "supported": false
+      },
+      "plan9-i386": {
+        "url": "https://dl.google.com/go/go1.24rc1.plan9-386.tar.gz",
+        "sha256": "3db9bfe05473be9d66501c8d67f8b974db801507bf0e6729de853755dfc2be1f",
+        "env": {
+          "GOOS": "plan9",
+          "GOARCH": "386"
+        },
+        "supported": false
+      },
+      "ppc64": {
+        "url": "https://dl.google.com/go/go1.24rc1.linux-ppc64.tar.gz",
+        "sha256": "b8ed018ce8cbcded82059d93af6ca7dd963e0228ae89986b52af6b82ac330c93",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "ppc64"
+        },
+        "supported": false
+      },
+      "ppc64le": {
+        "url": "https://dl.google.com/go/go1.24rc1.linux-ppc64le.tar.gz",
+        "sha256": "492eca7616fe51194886d5ae3a782d97559d7e8ba7e51ccb23fa1b32c79d96e9",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "ppc64le"
+        },
+        "supported": true
+      },
+      "riscv64": {
+        "url": "https://dl.google.com/go/go1.24rc1.linux-riscv64.tar.gz",
+        "sha256": "5cd2bc49913b0661a2f30d88fb80cd600477f66fa44b2d3d7002ce7fa7bffb91",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "riscv64",
+          "GORISCV64": "rva20u64"
+        },
+        "supported": true
+      },
+      "s390x": {
+        "url": "https://dl.google.com/go/go1.24rc1.linux-s390x.tar.gz",
+        "sha256": "13331e1c63c944b86602944945a2b87c88c002deaeea971b9930fd1d3b3e7a2c",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "s390x"
+        },
+        "supported": true
+      },
+      "solaris-amd64": {
+        "url": "https://dl.google.com/go/go1.24rc1.solaris-amd64.tar.gz",
+        "sha256": "93a6ff8026a22eac125e0fa428e23cc871ee82f81fa213a992c6ca6d07183777",
+        "env": {
+          "GOOS": "solaris",
+          "GOARCH": "amd64"
+        },
+        "supported": false
+      },
+      "src": {
+        "url": "https://dl.google.com/go/go1.24rc1.src.tar.gz",
+        "sha256": "afd8a23fd260f2a246d174049a076b8a05bb0bad93f1220768d219b8bdf7539d",
+        "supported": true
+      },
+      "windows-amd64": {
+        "url": "https://dl.google.com/go/go1.24rc1.windows-amd64.zip",
+        "sha256": "82690f356b18800c9c132a7010b8e9bf50977f408993f3d30f7b81a7c5a03c4d",
+        "env": {
+          "GOOS": "windows",
+          "GOARCH": "amd64"
+        },
+        "supported": true
+      },
+      "windows-arm64v8": {
+        "url": "https://dl.google.com/go/go1.24rc1.windows-arm64.zip",
+        "sha256": "e8b2c17c54fb39c73eb0c3286def04dc8b61a009f1b8c570295ecba8c5846955",
+        "env": {
+          "GOOS": "windows",
+          "GOARCH": "arm64"
+        },
+        "supported": false
+      },
+      "windows-i386": {
+        "url": "https://dl.google.com/go/go1.24rc1.windows-386.zip",
+        "sha256": "18e5ebe5bf7772cadd57e334991bee3fc5693557d27ebea4fa4d50cba7e8c518",
+        "env": {
+          "GOOS": "windows",
+          "GOARCH": "386"
+        },
+        "supported": false
+      }
+    },
+    "variants": [
+      "bookworm",
+      "bullseye",
+      "alpine3.21",
+      "alpine3.20",
+      "windows/windowsservercore-ltsc2022",
+      "windows/windowsservercore-1809",
+      "windows/nanoserver-ltsc2022",
+      "windows/nanoserver-1809"
+    ]
   }
 }


### PR DESCRIPTION
>Go 1.24 Release Candidate 1 is released
>Hello gophers,
> 
> We have just released go1.24rc1, a release candidate version of Go 1.24.
> It is cut from release-branch.go1.24 at the revision tagged go1.24rc1.
> 
> Please try your production load tests and unit tests with the new version.
> Your help testing these pre-release versions is invaluable.
> 
> Report any problems using the issue tracker:
> https://go.dev/issue/new
> 
> If you have Go installed already, an easy way to try go1.24rc1
> is by using the go command:
> 
> $ go install golang.org/dl/go1.24rc1@latest
> $ go1.24rc1 download
> You can download binary and source distributions from the usual place:
> https://go.dev/dl/#go1.24rc1
> 
> To find out what has changed in Go 1.24, read the draft release notes:
> https://tip.golang.org/doc/go1.24
> 
> Cheers,
> Carlos and Michael for the Go team