### PR TITLE
Update Git for Windows to 2.48.1

### DIFF
--- a/1.23/windows/windowsservercore-1809/Dockerfile
+++ b/1.23/windows/windowsservercore-1809/Dockerfile
@@ -10,13 +10,14 @@ FROM mcr.microsoft.com/windows/servercore:1809
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # install MinGit (especially for "go get")
-# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
-# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
-# "It currently requires only ~45MB on disk."
-ENV GIT_VERSION 2.23.0
+# https://github.com/git-for-windows/git/wiki/MinGit
+# https://gitforwindows.org/
+# https://github.com/git-for-windows/git/releases
+# TODO in some future release, consider the BusyBox variant?  maybe only once https://github.com/git-for-windows/git/issues/1439 is officially closed?
+ENV GIT_VERSION 2.48.1
 ENV GIT_TAG v${GIT_VERSION}.windows.1
 ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${GIT_TAG}/MinGit-${GIT_VERSION}-64-bit.zip
-ENV GIT_DOWNLOAD_SHA256 8f65208f92c0b4c3ae4c0cf02d4b5f6791d539cd1a07b2df62b7116467724735
+ENV GIT_DOWNLOAD_SHA256 11e8f462726827acccc7ecdad541f2544cbe5506d70fef4fa1ffac7c16288709
 # steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
 RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -42,6 +43,9 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	git version; \
 	\
 	Write-Host 'Complete.';
+# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
+# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
+# "It currently requires only ~45MB on disk."
 
 # for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
 ENV GOPATH C:\\go

--- a/1.23/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/1.23/windows/windowsservercore-ltsc2022/Dockerfile
@@ -10,13 +10,14 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2022
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # install MinGit (especially for "go get")
-# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
-# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
-# "It currently requires only ~45MB on disk."
-ENV GIT_VERSION 2.23.0
+# https://github.com/git-for-windows/git/wiki/MinGit
+# https://gitforwindows.org/
+# https://github.com/git-for-windows/git/releases
+# TODO in some future release, consider the BusyBox variant?  maybe only once https://github.com/git-for-windows/git/issues/1439 is officially closed?
+ENV GIT_VERSION 2.48.1
 ENV GIT_TAG v${GIT_VERSION}.windows.1
 ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${GIT_TAG}/MinGit-${GIT_VERSION}-64-bit.zip
-ENV GIT_DOWNLOAD_SHA256 8f65208f92c0b4c3ae4c0cf02d4b5f6791d539cd1a07b2df62b7116467724735
+ENV GIT_DOWNLOAD_SHA256 11e8f462726827acccc7ecdad541f2544cbe5506d70fef4fa1ffac7c16288709
 # steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
 RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -42,6 +43,9 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	git version; \
 	\
 	Write-Host 'Complete.';
+# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
+# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
+# "It currently requires only ~45MB on disk."
 
 # for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
 ENV GOPATH C:\\go

--- a/1.23/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/1.23/windows/windowsservercore-ltsc2025/Dockerfile
@@ -10,13 +10,14 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2025
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # install MinGit (especially for "go get")
-# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
-# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
-# "It currently requires only ~45MB on disk."
-ENV GIT_VERSION 2.23.0
+# https://github.com/git-for-windows/git/wiki/MinGit
+# https://gitforwindows.org/
+# https://github.com/git-for-windows/git/releases
+# TODO in some future release, consider the BusyBox variant?  maybe only once https://github.com/git-for-windows/git/issues/1439 is officially closed?
+ENV GIT_VERSION 2.48.1
 ENV GIT_TAG v${GIT_VERSION}.windows.1
 ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${GIT_TAG}/MinGit-${GIT_VERSION}-64-bit.zip
-ENV GIT_DOWNLOAD_SHA256 8f65208f92c0b4c3ae4c0cf02d4b5f6791d539cd1a07b2df62b7116467724735
+ENV GIT_DOWNLOAD_SHA256 11e8f462726827acccc7ecdad541f2544cbe5506d70fef4fa1ffac7c16288709
 # steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
 RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -42,6 +43,9 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	git version; \
 	\
 	Write-Host 'Complete.';
+# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
+# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
+# "It currently requires only ~45MB on disk."
 
 # for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
 ENV GOPATH C:\\go

--- a/1.24/windows/windowsservercore-1809/Dockerfile
+++ b/1.24/windows/windowsservercore-1809/Dockerfile
@@ -10,13 +10,14 @@ FROM mcr.microsoft.com/windows/servercore:1809
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # install MinGit (especially for "go get")
-# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
-# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
-# "It currently requires only ~45MB on disk."
-ENV GIT_VERSION 2.23.0
+# https://github.com/git-for-windows/git/wiki/MinGit
+# https://gitforwindows.org/
+# https://github.com/git-for-windows/git/releases
+# TODO in some future release, consider the BusyBox variant?  maybe only once https://github.com/git-for-windows/git/issues/1439 is officially closed?
+ENV GIT_VERSION 2.48.1
 ENV GIT_TAG v${GIT_VERSION}.windows.1
 ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${GIT_TAG}/MinGit-${GIT_VERSION}-64-bit.zip
-ENV GIT_DOWNLOAD_SHA256 8f65208f92c0b4c3ae4c0cf02d4b5f6791d539cd1a07b2df62b7116467724735
+ENV GIT_DOWNLOAD_SHA256 11e8f462726827acccc7ecdad541f2544cbe5506d70fef4fa1ffac7c16288709
 # steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
 RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -42,6 +43,9 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	git version; \
 	\
 	Write-Host 'Complete.';
+# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
+# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
+# "It currently requires only ~45MB on disk."
 
 # for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
 ENV GOPATH C:\\go

--- a/1.24/windows/windowsservercore-ltsc2022/Dockerfile
+++ b/1.24/windows/windowsservercore-ltsc2022/Dockerfile
@@ -10,13 +10,14 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2022
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # install MinGit (especially for "go get")
-# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
-# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
-# "It currently requires only ~45MB on disk."
-ENV GIT_VERSION 2.23.0
+# https://github.com/git-for-windows/git/wiki/MinGit
+# https://gitforwindows.org/
+# https://github.com/git-for-windows/git/releases
+# TODO in some future release, consider the BusyBox variant?  maybe only once https://github.com/git-for-windows/git/issues/1439 is officially closed?
+ENV GIT_VERSION 2.48.1
 ENV GIT_TAG v${GIT_VERSION}.windows.1
 ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${GIT_TAG}/MinGit-${GIT_VERSION}-64-bit.zip
-ENV GIT_DOWNLOAD_SHA256 8f65208f92c0b4c3ae4c0cf02d4b5f6791d539cd1a07b2df62b7116467724735
+ENV GIT_DOWNLOAD_SHA256 11e8f462726827acccc7ecdad541f2544cbe5506d70fef4fa1ffac7c16288709
 # steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
 RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -42,6 +43,9 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	git version; \
 	\
 	Write-Host 'Complete.';
+# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
+# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
+# "It currently requires only ~45MB on disk."
 
 # for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
 ENV GOPATH C:\\go

--- a/1.24/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/1.24/windows/windowsservercore-ltsc2025/Dockerfile
@@ -10,13 +10,14 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2025
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # install MinGit (especially for "go get")
-# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
-# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
-# "It currently requires only ~45MB on disk."
-ENV GIT_VERSION 2.23.0
+# https://github.com/git-for-windows/git/wiki/MinGit
+# https://gitforwindows.org/
+# https://github.com/git-for-windows/git/releases
+# TODO in some future release, consider the BusyBox variant?  maybe only once https://github.com/git-for-windows/git/issues/1439 is officially closed?
+ENV GIT_VERSION 2.48.1
 ENV GIT_TAG v${GIT_VERSION}.windows.1
 ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${GIT_TAG}/MinGit-${GIT_VERSION}-64-bit.zip
-ENV GIT_DOWNLOAD_SHA256 8f65208f92c0b4c3ae4c0cf02d4b5f6791d539cd1a07b2df62b7116467724735
+ENV GIT_DOWNLOAD_SHA256 11e8f462726827acccc7ecdad541f2544cbe5506d70fef4fa1ffac7c16288709
 # steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
 RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -42,6 +43,9 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	git version; \
 	\
 	Write-Host 'Complete.';
+# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
+# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
+# "It currently requires only ~45MB on disk."
 
 # for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
 ENV GOPATH C:\\go

--- a/Dockerfile-windows-servercore.template
+++ b/Dockerfile-windows-servercore.template
@@ -4,13 +4,14 @@ FROM mcr.microsoft.com/windows/{{ env.windowsVariant }}:{{ env.windowsRelease }}
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # install MinGit (especially for "go get")
-# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
-# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
-# "It currently requires only ~45MB on disk."
-ENV GIT_VERSION 2.23.0
+# https://github.com/git-for-windows/git/wiki/MinGit
+# https://gitforwindows.org/
+# https://github.com/git-for-windows/git/releases
+# TODO in some future release, consider the BusyBox variant?  maybe only once https://github.com/git-for-windows/git/issues/1439 is officially closed?
+ENV GIT_VERSION 2.48.1
 ENV GIT_TAG v${GIT_VERSION}.windows.1
 ENV GIT_DOWNLOAD_URL https://github.com/git-for-windows/git/releases/download/${GIT_TAG}/MinGit-${GIT_VERSION}-64-bit.zip
-ENV GIT_DOWNLOAD_SHA256 8f65208f92c0b4c3ae4c0cf02d4b5f6791d539cd1a07b2df62b7116467724735
+ENV GIT_DOWNLOAD_SHA256 11e8f462726827acccc7ecdad541f2544cbe5506d70fef4fa1ffac7c16288709
 # steps inspired by "chcolateyInstall.ps1" from "git.install" (https://chocolatey.org/packages/git.install)
 RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
@@ -36,6 +37,9 @@ RUN Write-Host ('Downloading {0} ...' -f $env:GIT_DOWNLOAD_URL); \
 	git version; \
 	\
 	Write-Host 'Complete.';
+# https://blogs.msdn.microsoft.com/visualstudioalm/2016/09/03/whats-new-in-git-for-windows-2-10/
+# "Essentially, it is a Git for Windows that was stripped down as much as possible without sacrificing the functionality in which 3rd-party software may be interested."
+# "It currently requires only ~45MB on disk."
 
 # for 1.17+, we'll follow the (new) Go upstream default for install (https://golang.org/cl/283600), which frees up C:\go to be the default GOPATH and thus match the Linux images more closely (https://github.com/docker-library/golang/issues/288)
 ENV GOPATH C:\\go


### PR DESCRIPTION
It's been a while since we updated this, we probably should (and maybe more often; perhaps automated). :see_no_evil: