### PR TITLE
Fix "tip" arches (and set "latest" alias automatically)

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,4 +1,409 @@
 {
+  "1.24": {
+    "version": "1.24.0",
+    "arches": {
+      "aix-ppc64": {
+        "url": "https://dl.google.com/go/go1.24.0.aix-ppc64.tar.gz",
+        "sha256": "5d04588154d5923bd8e26b76111806340ec55c41af1b05623ea744fcb3d6bc22",
+        "env": {
+          "GOOS": "aix",
+          "GOARCH": "ppc64"
+        },
+        "supported": false
+      },
+      "amd64": {
+        "url": "https://dl.google.com/go/go1.24.0.linux-amd64.tar.gz",
+        "sha256": "dea9ca38a0b852a74e81c26134671af7c0fbe65d81b0dc1c5bfe22cf7d4c8858",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "amd64",
+          "GOAMD64": "v1"
+        },
+        "supported": true
+      },
+      "arm32v5": {
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "arm",
+          "GOARM": "5"
+        },
+        "supported": false
+      },
+      "arm32v6": {
+        "url": "https://dl.google.com/go/go1.24.0.linux-armv6l.tar.gz",
+        "sha256": "695dc54fa14cd3124fa6900d7b5ae39eeac23f7a4ecea81656070160fac2c54a",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "arm",
+          "GOARM": "6"
+        },
+        "supported": true
+      },
+      "arm32v7": {
+        "url": "https://dl.google.com/go/go1.24.0.linux-armv6l.tar.gz",
+        "sha256": "695dc54fa14cd3124fa6900d7b5ae39eeac23f7a4ecea81656070160fac2c54a",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "arm",
+          "GOARM": "7"
+        },
+        "supported": true
+      },
+      "arm64v8": {
+        "url": "https://dl.google.com/go/go1.24.0.linux-arm64.tar.gz",
+        "sha256": "c3fa6d16ffa261091a5617145553c71d21435ce547e44cc6dfb7470865527cc7",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "arm64",
+          "GOARM64": "v8.0"
+        },
+        "supported": true
+      },
+      "darwin-amd64": {
+        "url": "https://dl.google.com/go/go1.24.0.darwin-amd64.tar.gz",
+        "sha256": "7af054e5088b68c24b3d6e135e5ca8d91bbd5a05cb7f7f0187367b3e6e9e05ee",
+        "env": {
+          "GOOS": "darwin",
+          "GOARCH": "amd64"
+        },
+        "supported": false
+      },
+      "darwin-arm64v8": {
+        "url": "https://dl.google.com/go/go1.24.0.darwin-arm64.tar.gz",
+        "sha256": "fd9cfb5dd6c75a347cfc641a253f0db1cebaca16b0dd37965351c6184ba595e4",
+        "env": {
+          "GOOS": "darwin",
+          "GOARCH": "arm64"
+        },
+        "supported": false
+      },
+      "dragonfly-amd64": {
+        "url": "https://dl.google.com/go/go1.24.0.dragonfly-amd64.tar.gz",
+        "sha256": "d0dc34ad86aea746abe245994c68a9e1ad8f46ba8c4af901cd5861a4dd4c21df",
+        "env": {
+          "GOOS": "dragonfly",
+          "GOARCH": "amd64"
+        },
+        "supported": false
+      },
+      "freebsd-amd64": {
+        "url": "https://dl.google.com/go/go1.24.0.freebsd-amd64.tar.gz",
+        "sha256": "838191001f9324da904dece35a586a3156d548687db87ac9461aa3d38fc88b09",
+        "env": {
+          "GOOS": "freebsd",
+          "GOARCH": "amd64"
+        },
+        "supported": false
+      },
+      "freebsd-arm": {
+        "url": "https://dl.google.com/go/go1.24.0.freebsd-arm.tar.gz",
+        "sha256": "ce6ad4e84a40a8a1d848b7e31b0cddfd1cee8f7959e7dc358a8fa8b5566ea718",
+        "env": {
+          "GOOS": "freebsd",
+          "GOARCH": "arm"
+        },
+        "supported": false
+      },
+      "freebsd-arm64v8": {
+        "url": "https://dl.google.com/go/go1.24.0.freebsd-arm64.tar.gz",
+        "sha256": "511f7b0cac4c4ed1066d324072ce223b906ad6b2a85f2e1c5d260eb7d08b5901",
+        "env": {
+          "GOOS": "freebsd",
+          "GOARCH": "arm64"
+        },
+        "supported": false
+      },
+      "freebsd-i386": {
+        "url": "https://dl.google.com/go/go1.24.0.freebsd-386.tar.gz",
+        "sha256": "4ee02b1f3812aff4da79c79464ee4038ca61ad74b3a9619850f30435f81c2536",
+        "env": {
+          "GOOS": "freebsd",
+          "GOARCH": "386"
+        },
+        "supported": false
+      },
+      "freebsd-riscv64": {
+        "url": "https://dl.google.com/go/go1.24.0.freebsd-riscv64.tar.gz",
+        "sha256": "a1e4072630dc589a2975ef51317b52c7d8599bf6f389fc59033c01e0a0fa705a",
+        "env": {
+          "GOOS": "freebsd",
+          "GOARCH": "riscv64"
+        },
+        "supported": false
+      },
+      "i386": {
+        "url": "https://dl.google.com/go/go1.24.0.linux-386.tar.gz",
+        "sha256": "90521453a59c6ce20364d2dc7c38532949b033b602ba12d782caeb90af1b0624",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "386",
+          "GO386": "softfloat"
+        },
+        "supported": true
+      },
+      "illumos-amd64": {
+        "url": "https://dl.google.com/go/go1.24.0.illumos-amd64.tar.gz",
+        "sha256": "7593e9dcee9f07c3df6d099f7d259f5734a6c0dccc5f28962f18e7f501c9bb21",
+        "env": {
+          "GOOS": "illumos",
+          "GOARCH": "amd64"
+        },
+        "supported": false
+      },
+      "loong64": {
+        "url": "https://dl.google.com/go/go1.24.0.linux-loong64.tar.gz",
+        "sha256": "a201e4c9b7e6d29ed64c43296ed88e81a66f82f2093ce45b766d2c526941396f",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "loong64"
+        },
+        "supported": false
+      },
+      "mips": {
+        "url": "https://dl.google.com/go/go1.24.0.linux-mips.tar.gz",
+        "sha256": "f3ac039aae78ad0bfb08106406c2e62eaf763dd82ebaf0ecd539adadd1d729a6",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "mips"
+        },
+        "supported": false
+      },
+      "mips64": {
+        "url": "https://dl.google.com/go/go1.24.0.linux-mips64.tar.gz",
+        "sha256": "f2e6456d45e024831b1da8d88b1bb6392cca9500c1b00841f525d76c9e9553e0",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "mips64"
+        },
+        "supported": false
+      },
+      "mips64le": {
+        "url": "https://dl.google.com/go/go1.24.0.linux-mips64le.tar.gz",
+        "sha256": "b847893ff119389c939adc2b8516b6500204b7cb49d5e19b25e1c2091d2c74c6",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "mips64le"
+        },
+        "supported": true
+      },
+      "mipsle": {
+        "url": "https://dl.google.com/go/go1.24.0.linux-mipsle.tar.gz",
+        "sha256": "bd4aed27d02746c237c3921e97029ac6b6fe687a67436b8f52ff1f698d330bd9",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "mipsle"
+        },
+        "supported": false
+      },
+      "netbsd-amd64": {
+        "url": "https://dl.google.com/go/go1.24.0.netbsd-amd64.tar.gz",
+        "sha256": "67150a6dd7bdb9c4e88d77f46ee8c4dc99d5e71deca4912d8c2c85f7a16d0262",
+        "env": {
+          "GOOS": "netbsd",
+          "GOARCH": "amd64"
+        },
+        "supported": false
+      },
+      "netbsd-arm": {
+        "url": "https://dl.google.com/go/go1.24.0.netbsd-arm.tar.gz",
+        "sha256": "446b2539f11218fd6f6f6e3dd90b20ae55a06afe129885eeb3df51eb344eb0f6",
+        "env": {
+          "GOOS": "netbsd",
+          "GOARCH": "arm"
+        },
+        "supported": false
+      },
+      "netbsd-arm64v8": {
+        "url": "https://dl.google.com/go/go1.24.0.netbsd-arm64.tar.gz",
+        "sha256": "370115b6ff7d30b29431223de348eb11ab65e3c92627532d97fd55f63f94e7a8",
+        "env": {
+          "GOOS": "netbsd",
+          "GOARCH": "arm64"
+        },
+        "supported": false
+      },
+      "netbsd-i386": {
+        "url": "https://dl.google.com/go/go1.24.0.netbsd-386.tar.gz",
+        "sha256": "8b143a7edefbaa2a0b0246c9df2df1bac9fbed909d8615a375c08da7744e697d",
+        "env": {
+          "GOOS": "netbsd",
+          "GOARCH": "386"
+        },
+        "supported": false
+      },
+      "openbsd-amd64": {
+        "url": "https://dl.google.com/go/go1.24.0.openbsd-amd64.tar.gz",
+        "sha256": "926f601d0e655ab1e8d7f357fd82542e5cf206c38c4e2f9fccf0706987d38836",
+        "env": {
+          "GOOS": "openbsd",
+          "GOARCH": "amd64"
+        },
+        "supported": false
+      },
+      "openbsd-arm": {
+        "url": "https://dl.google.com/go/go1.24.0.openbsd-arm.tar.gz",
+        "sha256": "8a54892f8c933c541fff144a825d0fdc41bae14b0832aab703cb75eb4cb64f2c",
+        "env": {
+          "GOOS": "openbsd",
+          "GOARCH": "arm"
+        },
+        "supported": false
+      },
+      "openbsd-arm64v8": {
+        "url": "https://dl.google.com/go/go1.24.0.openbsd-arm64.tar.gz",
+        "sha256": "ef7fddcef0a22c7900c178b7687cf5aa25c2a9d46a3cc330b77a6de6e6c2396b",
+        "env": {
+          "GOOS": "openbsd",
+          "GOARCH": "arm64"
+        },
+        "supported": false
+      },
+      "openbsd-i386": {
+        "url": "https://dl.google.com/go/go1.24.0.openbsd-386.tar.gz",
+        "sha256": "cbda5f15f06ed9630f122a53542d9de13d149643633c74f1dcb45e79649b788a",
+        "env": {
+          "GOOS": "openbsd",
+          "GOARCH": "386"
+        },
+        "supported": false
+      },
+      "openbsd-ppc64": {
+        "url": "https://dl.google.com/go/go1.24.0.openbsd-ppc64.tar.gz",
+        "sha256": "b3b5e2e2b53489ded2c2c21900ddcbbdb7991632bb5b42f05f125d71675e0b76",
+        "env": {
+          "GOOS": "openbsd",
+          "GOARCH": "ppc64"
+        },
+        "supported": false
+      },
+      "openbsd-riscv64": {
+        "url": "https://dl.google.com/go/go1.24.0.openbsd-riscv64.tar.gz",
+        "sha256": "fbcb1dbf1269b4079dc4fd0b15f3274b9d635f1a7e319c3fc1a907b03280348e",
+        "env": {
+          "GOOS": "openbsd",
+          "GOARCH": "riscv64"
+        },
+        "supported": false
+      },
+      "plan9-amd64": {
+        "url": "https://dl.google.com/go/go1.24.0.plan9-amd64.tar.gz",
+        "sha256": "111a89014019cdbd69c2978de9b3e201f77e35183c8ab3606fba339d38f28549",
+        "env": {
+          "GOOS": "plan9",
+          "GOARCH": "amd64"
+        },
+        "supported": false
+      },
+      "plan9-arm": {
+        "url": "https://dl.google.com/go/go1.24.0.plan9-arm.tar.gz",
+        "sha256": "8da3d3997049f40ebe0cd336a9bb9e4bfa4832df3c90a32f07383371d6d74849",
+        "env": {
+          "GOOS": "plan9",
+          "GOARCH": "arm"
+        },
+        "supported": false
+      },
+      "plan9-i386": {
+        "url": "https://dl.google.com/go/go1.24.0.plan9-386.tar.gz",
+        "sha256": "33b4221e1c174a16e3f661deab6c60838ac4ae6cb869a4da1d1115773ceed88b",
+        "env": {
+          "GOOS": "plan9",
+          "GOARCH": "386"
+        },
+        "supported": false
+      },
+      "ppc64": {
+        "url": "https://dl.google.com/go/go1.24.0.linux-ppc64.tar.gz",
+        "sha256": "007123c9b06c41729a4bb3f166f4df7196adf4e33c2d2ab0e7e990175f0ce1d4",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "ppc64"
+        },
+        "supported": false
+      },
+      "ppc64le": {
+        "url": "https://dl.google.com/go/go1.24.0.linux-ppc64le.tar.gz",
+        "sha256": "a871a43de7d26c91dd90cb6e0adacb214c9e35ee2188c617c91c08c017efe81a",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "ppc64le"
+        },
+        "supported": true
+      },
+      "riscv64": {
+        "url": "https://dl.google.com/go/go1.24.0.linux-riscv64.tar.gz",
+        "sha256": "620dcf48c6297519aad6c81f8e344926dc0ab09a2a79f1e306964aece95a553d",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "riscv64",
+          "GORISCV64": "rva20u64"
+        },
+        "supported": true
+      },
+      "s390x": {
+        "url": "https://dl.google.com/go/go1.24.0.linux-s390x.tar.gz",
+        "sha256": "544d78b077c6b54bf78958c4a8285abec2d21f668fb007261c77418cd2edbb46",
+        "env": {
+          "GOOS": "linux",
+          "GOARCH": "s390x"
+        },
+        "supported": true
+      },
+      "solaris-amd64": {
+        "url": "https://dl.google.com/go/go1.24.0.solaris-amd64.tar.gz",
+        "sha256": "b6069da21dc95ccdbd047675b584e5480ffc3eba35f9e7c8b0e7b317aaf01e2c",
+        "env": {
+          "GOOS": "solaris",
+          "GOARCH": "amd64"
+        },
+        "supported": false
+      },
+      "src": {
+        "url": "https://dl.google.com/go/go1.24.0.src.tar.gz",
+        "sha256": "d14120614acb29d12bcab72bd689f257eb4be9e0b6f88a8fb7e41ac65f8556e5",
+        "supported": false
+      },
+      "windows-amd64": {
+        "url": "https://dl.google.com/go/go1.24.0.windows-amd64.zip",
+        "sha256": "96b7280979205813759ee6947be7e3bb497da85c482711116c00522e3bb41ff1",
+        "env": {
+          "GOOS": "windows",
+          "GOARCH": "amd64"
+        },
+        "supported": true
+      },
+      "windows-arm64v8": {
+        "url": "https://dl.google.com/go/go1.24.0.windows-arm64.zip",
+        "sha256": "53f73450fb66075d16be9f206e9177bd972b528168271918c4747903b5596c3d",
+        "env": {
+          "GOOS": "windows",
+          "GOARCH": "arm64"
+        },
+        "supported": false
+      },
+      "windows-i386": {
+        "url": "https://dl.google.com/go/go1.24.0.windows-386.zip",
+        "sha256": "b53c28a4c2863ec50ab4a1dbebe818ef6177f86773b6f43475d40a5d9aa4ec9e",
+        "env": {
+          "GOOS": "windows",
+          "GOARCH": "386"
+        },
+        "supported": false
+      }
+    },
+    "variants": [
+      "bookworm",
+      "bullseye",
+      "alpine3.21",
+      "alpine3.20",
+      "windows/windowsservercore-ltsc2025",
+      "windows/windowsservercore-ltsc2022",
+      "windows/windowsservercore-1809",
+      "windows/nanoserver-ltsc2025",
+      "windows/nanoserver-ltsc2022",
+      "windows/nanoserver-1809"
+    ]
+  },
   "1.23": {
     "version": "1.23.6",
     "arches": {
@@ -393,411 +798,6 @@
       "windows-i386": {
         "url": "https://dl.google.com/go/go1.23.6.windows-386.zip",
         "sha256": "96820c0f5d464dd694543329e9b4d413b17c821c03a055717a29e6735b44c2d8",
-        "env": {
-          "GOOS": "windows",
-          "GOARCH": "386"
-        },
-        "supported": false
-      }
-    },
-    "variants": [
-      "bookworm",
-      "bullseye",
-      "alpine3.21",
-      "alpine3.20",
-      "windows/windowsservercore-ltsc2025",
-      "windows/windowsservercore-ltsc2022",
-      "windows/windowsservercore-1809",
-      "windows/nanoserver-ltsc2025",
-      "windows/nanoserver-ltsc2022",
-      "windows/nanoserver-1809"
-    ]
-  },
-  "1.24": {
-    "version": "1.24.0",
-    "arches": {
-      "aix-ppc64": {
-        "url": "https://dl.google.com/go/go1.24.0.aix-ppc64.tar.gz",
-        "sha256": "5d04588154d5923bd8e26b76111806340ec55c41af1b05623ea744fcb3d6bc22",
-        "env": {
-          "GOOS": "aix",
-          "GOARCH": "ppc64"
-        },
-        "supported": false
-      },
-      "amd64": {
-        "url": "https://dl.google.com/go/go1.24.0.linux-amd64.tar.gz",
-        "sha256": "dea9ca38a0b852a74e81c26134671af7c0fbe65d81b0dc1c5bfe22cf7d4c8858",
-        "env": {
-          "GOOS": "linux",
-          "GOARCH": "amd64",
-          "GOAMD64": "v1"
-        },
-        "supported": true
-      },
-      "arm32v5": {
-        "env": {
-          "GOOS": "linux",
-          "GOARCH": "arm",
-          "GOARM": "5"
-        },
-        "supported": false
-      },
-      "arm32v6": {
-        "url": "https://dl.google.com/go/go1.24.0.linux-armv6l.tar.gz",
-        "sha256": "695dc54fa14cd3124fa6900d7b5ae39eeac23f7a4ecea81656070160fac2c54a",
-        "env": {
-          "GOOS": "linux",
-          "GOARCH": "arm",
-          "GOARM": "6"
-        },
-        "supported": true
-      },
-      "arm32v7": {
-        "url": "https://dl.google.com/go/go1.24.0.linux-armv6l.tar.gz",
-        "sha256": "695dc54fa14cd3124fa6900d7b5ae39eeac23f7a4ecea81656070160fac2c54a",
-        "env": {
-          "GOOS": "linux",
-          "GOARCH": "arm",
-          "GOARM": "7"
-        },
-        "supported": true
-      },
-      "arm64v8": {
-        "url": "https://dl.google.com/go/go1.24.0.linux-arm64.tar.gz",
-        "sha256": "c3fa6d16ffa261091a5617145553c71d21435ce547e44cc6dfb7470865527cc7",
-        "env": {
-          "GOOS": "linux",
-          "GOARCH": "arm64",
-          "GOARM64": "v8.0"
-        },
-        "supported": true
-      },
-      "darwin-amd64": {
-        "url": "https://dl.google.com/go/go1.24.0.darwin-amd64.tar.gz",
-        "sha256": "7af054e5088b68c24b3d6e135e5ca8d91bbd5a05cb7f7f0187367b3e6e9e05ee",
-        "env": {
-          "GOOS": "darwin",
-          "GOARCH": "amd64"
-        },
-        "supported": false
-      },
-      "darwin-arm64v8": {
-        "url": "https://dl.google.com/go/go1.24.0.darwin-arm64.tar.gz",
-        "sha256": "fd9cfb5dd6c75a347cfc641a253f0db1cebaca16b0dd37965351c6184ba595e4",
-        "env": {
-          "GOOS": "darwin",
-          "GOARCH": "arm64"
-        },
-        "supported": false
-      },
-      "dragonfly-amd64": {
-        "url": "https://dl.google.com/go/go1.24.0.dragonfly-amd64.tar.gz",
-        "sha256": "d0dc34ad86aea746abe245994c68a9e1ad8f46ba8c4af901cd5861a4dd4c21df",
-        "env": {
-          "GOOS": "dragonfly",
-          "GOARCH": "amd64"
-        },
-        "supported": false
-      },
-      "freebsd-amd64": {
-        "url": "https://dl.google.com/go/go1.24.0.freebsd-amd64.tar.gz",
-        "sha256": "838191001f9324da904dece35a586a3156d548687db87ac9461aa3d38fc88b09",
-        "env": {
-          "GOOS": "freebsd",
-          "GOARCH": "amd64"
-        },
-        "supported": false
-      },
-      "freebsd-arm": {
-        "url": "https://dl.google.com/go/go1.24.0.freebsd-arm.tar.gz",
-        "sha256": "ce6ad4e84a40a8a1d848b7e31b0cddfd1cee8f7959e7dc358a8fa8b5566ea718",
-        "env": {
-          "GOOS": "freebsd",
-          "GOARCH": "arm"
-        },
-        "supported": false
-      },
-      "freebsd-arm64v8": {
-        "url": "https://dl.google.com/go/go1.24.0.freebsd-arm64.tar.gz",
-        "sha256": "511f7b0cac4c4ed1066d324072ce223b906ad6b2a85f2e1c5d260eb7d08b5901",
-        "env": {
-          "GOOS": "freebsd",
-          "GOARCH": "arm64"
-        },
-        "supported": false
-      },
-      "freebsd-i386": {
-        "url": "https://dl.google.com/go/go1.24.0.freebsd-386.tar.gz",
-        "sha256": "4ee02b1f3812aff4da79c79464ee4038ca61ad74b3a9619850f30435f81c2536",
-        "env": {
-          "GOOS": "freebsd",
-          "GOARCH": "386"
-        },
-        "supported": false
-      },
-      "freebsd-riscv64": {
-        "url": "https://dl.google.com/go/go1.24.0.freebsd-riscv64.tar.gz",
-        "sha256": "a1e4072630dc589a2975ef51317b52c7d8599bf6f389fc59033c01e0a0fa705a",
-        "env": {
-          "GOOS": "freebsd",
-          "GOARCH": "riscv64"
-        },
-        "supported": false
-      },
-      "i386": {
-        "url": "https://dl.google.com/go/go1.24.0.linux-386.tar.gz",
-        "sha256": "90521453a59c6ce20364d2dc7c38532949b033b602ba12d782caeb90af1b0624",
-        "env": {
-          "GOOS": "linux",
-          "GOARCH": "386",
-          "GO386": "softfloat"
-        },
-        "supported": true
-      },
-      "illumos-amd64": {
-        "url": "https://dl.google.com/go/go1.24.0.illumos-amd64.tar.gz",
-        "sha256": "7593e9dcee9f07c3df6d099f7d259f5734a6c0dccc5f28962f18e7f501c9bb21",
-        "env": {
-          "GOOS": "illumos",
-          "GOARCH": "amd64"
-        },
-        "supported": false
-      },
-      "loong64": {
-        "url": "https://dl.google.com/go/go1.24.0.linux-loong64.tar.gz",
-        "sha256": "a201e4c9b7e6d29ed64c43296ed88e81a66f82f2093ce45b766d2c526941396f",
-        "env": {
-          "GOOS": "linux",
-          "GOARCH": "loong64"
-        },
-        "supported": false
-      },
-      "mips": {
-        "url": "https://dl.google.com/go/go1.24.0.linux-mips.tar.gz",
-        "sha256": "f3ac039aae78ad0bfb08106406c2e62eaf763dd82ebaf0ecd539adadd1d729a6",
-        "env": {
-          "GOOS": "linux",
-          "GOARCH": "mips"
-        },
-        "supported": false
-      },
-      "mips64": {
-        "url": "https://dl.google.com/go/go1.24.0.linux-mips64.tar.gz",
-        "sha256": "f2e6456d45e024831b1da8d88b1bb6392cca9500c1b00841f525d76c9e9553e0",
-        "env": {
-          "GOOS": "linux",
-          "GOARCH": "mips64"
-        },
-        "supported": false
-      },
-      "mips64le": {
-        "url": "https://dl.google.com/go/go1.24.0.linux-mips64le.tar.gz",
-        "sha256": "b847893ff119389c939adc2b8516b6500204b7cb49d5e19b25e1c2091d2c74c6",
-        "env": {
-          "GOOS": "linux",
-          "GOARCH": "mips64le"
-        },
-        "supported": true
-      },
-      "mipsle": {
-        "url": "https://dl.google.com/go/go1.24.0.linux-mipsle.tar.gz",
-        "sha256": "bd4aed27d02746c237c3921e97029ac6b6fe687a67436b8f52ff1f698d330bd9",
-        "env": {
-          "GOOS": "linux",
-          "GOARCH": "mipsle"
-        },
-        "supported": false
-      },
-      "netbsd-amd64": {
-        "url": "https://dl.google.com/go/go1.24.0.netbsd-amd64.tar.gz",
-        "sha256": "67150a6dd7bdb9c4e88d77f46ee8c4dc99d5e71deca4912d8c2c85f7a16d0262",
-        "env": {
-          "GOOS": "netbsd",
-          "GOARCH": "amd64"
-        },
-        "supported": false
-      },
-      "netbsd-arm": {
-        "url": "https://dl.google.com/go/go1.24.0.netbsd-arm.tar.gz",
-        "sha256": "446b2539f11218fd6f6f6e3dd90b20ae55a06afe129885eeb3df51eb344eb0f6",
-        "env": {
-          "GOOS": "netbsd",
-          "GOARCH": "arm"
-        },
-        "supported": false
-      },
-      "netbsd-arm64v8": {
-        "url": "https://dl.google.com/go/go1.24.0.netbsd-arm64.tar.gz",
-        "sha256": "370115b6ff7d30b29431223de348eb11ab65e3c92627532d97fd55f63f94e7a8",
-        "env": {
-          "GOOS": "netbsd",
-          "GOARCH": "arm64"
-        },
-        "supported": false
-      },
-      "netbsd-i386": {
-        "url": "https://dl.google.com/go/go1.24.0.netbsd-386.tar.gz",
-        "sha256": "8b143a7edefbaa2a0b0246c9df2df1bac9fbed909d8615a375c08da7744e697d",
-        "env": {
-          "GOOS": "netbsd",
-          "GOARCH": "386"
-        },
-        "supported": false
-      },
-      "openbsd-amd64": {
-        "url": "https://dl.google.com/go/go1.24.0.openbsd-amd64.tar.gz",
-        "sha256": "926f601d0e655ab1e8d7f357fd82542e5cf206c38c4e2f9fccf0706987d38836",
-        "env": {
-          "GOOS": "openbsd",
-          "GOARCH": "amd64"
-        },
-        "supported": false
-      },
-      "openbsd-arm": {
-        "url": "https://dl.google.com/go/go1.24.0.openbsd-arm.tar.gz",
-        "sha256": "8a54892f8c933c541fff144a825d0fdc41bae14b0832aab703cb75eb4cb64f2c",
-        "env": {
-          "GOOS": "openbsd",
-          "GOARCH": "arm"
-        },
-        "supported": false
-      },
-      "openbsd-arm64v8": {
-        "url": "https://dl.google.com/go/go1.24.0.openbsd-arm64.tar.gz",
-        "sha256": "ef7fddcef0a22c7900c178b7687cf5aa25c2a9d46a3cc330b77a6de6e6c2396b",
-        "env": {
-          "GOOS": "openbsd",
-          "GOARCH": "arm64"
-        },
-        "supported": false
-      },
-      "openbsd-i386": {
-        "url": "https://dl.google.com/go/go1.24.0.openbsd-386.tar.gz",
-        "sha256": "cbda5f15f06ed9630f122a53542d9de13d149643633c74f1dcb45e79649b788a",
-        "env": {
-          "GOOS": "openbsd",
-          "GOARCH": "386"
-        },
-        "supported": false
-      },
-      "openbsd-ppc64": {
-        "url": "https://dl.google.com/go/go1.24.0.openbsd-ppc64.tar.gz",
-        "sha256": "b3b5e2e2b53489ded2c2c21900ddcbbdb7991632bb5b42f05f125d71675e0b76",
-        "env": {
-          "GOOS": "openbsd",
-          "GOARCH": "ppc64"
-        },
-        "supported": false
-      },
-      "openbsd-riscv64": {
-        "url": "https://dl.google.com/go/go1.24.0.openbsd-riscv64.tar.gz",
-        "sha256": "fbcb1dbf1269b4079dc4fd0b15f3274b9d635f1a7e319c3fc1a907b03280348e",
-        "env": {
-          "GOOS": "openbsd",
-          "GOARCH": "riscv64"
-        },
-        "supported": false
-      },
-      "plan9-amd64": {
-        "url": "https://dl.google.com/go/go1.24.0.plan9-amd64.tar.gz",
-        "sha256": "111a89014019cdbd69c2978de9b3e201f77e35183c8ab3606fba339d38f28549",
-        "env": {
-          "GOOS": "plan9",
-          "GOARCH": "amd64"
-        },
-        "supported": false
-      },
-      "plan9-arm": {
-        "url": "https://dl.google.com/go/go1.24.0.plan9-arm.tar.gz",
-        "sha256": "8da3d3997049f40ebe0cd336a9bb9e4bfa4832df3c90a32f07383371d6d74849",
-        "env": {
-          "GOOS": "plan9",
-          "GOARCH": "arm"
-        },
-        "supported": false
-      },
-      "plan9-i386": {
-        "url": "https://dl.google.com/go/go1.24.0.plan9-386.tar.gz",
-        "sha256": "33b4221e1c174a16e3f661deab6c60838ac4ae6cb869a4da1d1115773ceed88b",
-        "env": {
-          "GOOS": "plan9",
-          "GOARCH": "386"
-        },
-        "supported": false
-      },
-      "ppc64": {
-        "url": "https://dl.google.com/go/go1.24.0.linux-ppc64.tar.gz",
-        "sha256": "007123c9b06c41729a4bb3f166f4df7196adf4e33c2d2ab0e7e990175f0ce1d4",
-        "env": {
-          "GOOS": "linux",
-          "GOARCH": "ppc64"
-        },
-        "supported": false
-      },
-      "ppc64le": {
-        "url": "https://dl.google.com/go/go1.24.0.linux-ppc64le.tar.gz",
-        "sha256": "a871a43de7d26c91dd90cb6e0adacb214c9e35ee2188c617c91c08c017efe81a",
-        "env": {
-          "GOOS": "linux",
-          "GOARCH": "ppc64le"
-        },
-        "supported": true
-      },
-      "riscv64": {
-        "url": "https://dl.google.com/go/go1.24.0.linux-riscv64.tar.gz",
-        "sha256": "620dcf48c6297519aad6c81f8e344926dc0ab09a2a79f1e306964aece95a553d",
-        "env": {
-          "GOOS": "linux",
-          "GOARCH": "riscv64",
-          "GORISCV64": "rva20u64"
-        },
-        "supported": true
-      },
-      "s390x": {
-        "url": "https://dl.google.com/go/go1.24.0.linux-s390x.tar.gz",
-        "sha256": "544d78b077c6b54bf78958c4a8285abec2d21f668fb007261c77418cd2edbb46",
-        "env": {
-          "GOOS": "linux",
-          "GOARCH": "s390x"
-        },
-        "supported": true
-      },
-      "solaris-amd64": {
-        "url": "https://dl.google.com/go/go1.24.0.solaris-amd64.tar.gz",
-        "sha256": "b6069da21dc95ccdbd047675b584e5480ffc3eba35f9e7c8b0e7b317aaf01e2c",
-        "env": {
-          "GOOS": "solaris",
-          "GOARCH": "amd64"
-        },
-        "supported": false
-      },
-      "src": {
-        "url": "https://dl.google.com/go/go1.24.0.src.tar.gz",
-        "sha256": "d14120614acb29d12bcab72bd689f257eb4be9e0b6f88a8fb7e41ac65f8556e5",
-        "supported": false
-      },
-      "windows-amd64": {
-        "url": "https://dl.google.com/go/go1.24.0.windows-amd64.zip",
-        "sha256": "96b7280979205813759ee6947be7e3bb497da85c482711116c00522e3bb41ff1",
-        "env": {
-          "GOOS": "windows",
-          "GOARCH": "amd64"
-        },
-        "supported": true
-      },
-      "windows-arm64v8": {
-        "url": "https://dl.google.com/go/go1.24.0.windows-arm64.zip",
-        "sha256": "53f73450fb66075d16be9f206e9177bd972b528168271918c4747903b5596c3d",
-        "env": {
-          "GOOS": "windows",
-          "GOARCH": "arm64"
-        },
-        "supported": false
-      },
-      "windows-i386": {
-        "url": "https://dl.google.com/go/go1.24.0.windows-386.zip",
-        "sha256": "b53c28a4c2863ec50ab4a1dbebe818ef6177f86773b6f43475d40a5d9aa4ec9e",
         "env": {
           "GOOS": "windows",
           "GOARCH": "386"

--- a/versions.sh
+++ b/versions.sh
@@ -266,11 +266,19 @@ for version in "${versions[@]}"; do
 done
 
 jq <<<"$json" '
-	def sort_keys:
+	to_entries
+	| sort_by(
+		.key
+		| [
+			if . == "tip" then 0 else 1 end, # make sure tip is first so it ends up last when we reverse
+			(split("[.-]"; "") | map(tonumber? // .))
+		]
+	)
+	| reverse
+	| from_entries
+	| .[].arches |= (
 		to_entries
 		| sort_by(.key)
 		| from_entries
-	;
-	sort_keys
-	| .[].arches |= sort_keys
+	)
 ' > versions.json


### PR DESCRIPTION
This is a follow-up to https://github.com/docker-library/golang/pull/531, specifically to fix https://github.com/docker-library/golang/pull/531#issuecomment-2660180621

This exhibits as `arm32v5` being in the list of "supported" architectures for `golang:tip` even though the `golang:latest` it copies from doesn't ever support that architecture (and thus the downstream "naughty `FROM`" script gives us `- golang:tip-20250209-bookworm (FROM golang:bookworm) [arm32v5]`).

This updates our code to pre-sort `versions.json` so that it's descending version order with `tip` last -- technically we could argue that `-rc` versions should be below GA versions (but above `tip`), but maybe that's a future improvement.  Happy to implement if that goes in here (especially as it would make the "what's `latest`" calculation even simpler :joy:).