### PR TITLE
Slightly different `date` value to get updates Monday

### DIFF
--- a/versions.sh
+++ b/versions.sh
@@ -93,7 +93,7 @@ for version in "${versions[@]}"; do
 			# clamp so we don't update too frequently (https://github.com/docker-library/golang/issues/464#issuecomment-1587758290, https://github.com/docker-library/faq#can-i-use-a-bot-to-make-my-image-update-prs)
 			# https://github.com/golang/go
 			# https://go.googlesource.com/go
-			snapshotDate="$(date --utc --date 'last monday 00:00:00' '+%s')"
+			snapshotDate="$(date --utc --date 'last sunday 23:59:59 UTC + 1 second' '+%s')"
 			snapshotDateStr="$(date --utc --date "@$snapshotDate" '+%Y-%m-%d @ %H:%M:%S')"
 			commit='HEAD' # this is also our iteration variable, so if we don't find a suitable commit each time through this loop, we'll use the last commit of the previous list to get a list of new (older) commits until we find one suitably old enough
 			fullVersion=


### PR DESCRIPTION
I intended for this to update every Monday (with "the last week's changes", including the weekend), but `last monday` doesn't match my intent until *Tuesday*, so this fixes that boundary condition by using `last sunday` instead, one second to midnight, and using date math to add a second.

I also found that even with `--utc`, I had to explicitly specify `UTC` in my string or it would be off by an hour.