### PR TITLE
Explicitly install `gold` on `arm64`

### DIFF
--- a/1.24/bookworm/Dockerfile
+++ b/1.24/bookworm/Dockerfile
@@ -114,6 +114,16 @@ RUN set -eux; \
 		make \
 		pkg-config \
 	; \
+# go depends on "gold" explicitly on arm64
+# https://github.com/docker-library/golang/issues/570 (go depends on "gold" explicitly on arm64)
+# https://github.com/golang/go/issues/22040
+# ... and as of trixie, "gold" is removed from the "binutils" package:
+# > WARNING: gold is being removed from binutils, and is deprecated upstream.
+# (and available as "binutils-gold" which is also a virtual on bookworm so we can reasonably be explicit everywhere)
+	dpkgArch="$(dpkg --print-architecture)"; \
+	if [ "$dpkgArch" = 'arm64' ]; then \
+		apt-get install -y --no-install-recommends binutils-gold; \
+	fi; \
 	rm -rf /var/lib/apt/lists/*
 
 ENV GOLANG_VERSION 1.24.6

--- a/1.24/trixie/Dockerfile
+++ b/1.24/trixie/Dockerfile
@@ -114,6 +114,16 @@ RUN set -eux; \
 		make \
 		pkg-config \
 	; \
+# go depends on "gold" explicitly on arm64
+# https://github.com/docker-library/golang/issues/570 (go depends on "gold" explicitly on arm64)
+# https://github.com/golang/go/issues/22040
+# ... and as of trixie, "gold" is removed from the "binutils" package:
+# > WARNING: gold is being removed from binutils, and is deprecated upstream.
+# (and available as "binutils-gold" which is also a virtual on bookworm so we can reasonably be explicit everywhere)
+	dpkgArch="$(dpkg --print-architecture)"; \
+	if [ "$dpkgArch" = 'arm64' ]; then \
+		apt-get install -y --no-install-recommends binutils-gold; \
+	fi; \
 	rm -rf /var/lib/apt/lists/*
 
 ENV GOLANG_VERSION 1.24.6

--- a/1.25/bookworm/Dockerfile
+++ b/1.25/bookworm/Dockerfile
@@ -114,6 +114,16 @@ RUN set -eux; \
 		make \
 		pkg-config \
 	; \
+# go depends on "gold" explicitly on arm64
+# https://github.com/docker-library/golang/issues/570 (go depends on "gold" explicitly on arm64)
+# https://github.com/golang/go/issues/22040
+# ... and as of trixie, "gold" is removed from the "binutils" package:
+# > WARNING: gold is being removed from binutils, and is deprecated upstream.
+# (and available as "binutils-gold" which is also a virtual on bookworm so we can reasonably be explicit everywhere)
+	dpkgArch="$(dpkg --print-architecture)"; \
+	if [ "$dpkgArch" = 'arm64' ]; then \
+		apt-get install -y --no-install-recommends binutils-gold; \
+	fi; \
 	rm -rf /var/lib/apt/lists/*
 
 ENV GOLANG_VERSION 1.25.0

--- a/1.25/trixie/Dockerfile
+++ b/1.25/trixie/Dockerfile
@@ -114,6 +114,16 @@ RUN set -eux; \
 		make \
 		pkg-config \
 	; \
+# go depends on "gold" explicitly on arm64
+# https://github.com/docker-library/golang/issues/570 (go depends on "gold" explicitly on arm64)
+# https://github.com/golang/go/issues/22040
+# ... and as of trixie, "gold" is removed from the "binutils" package:
+# > WARNING: gold is being removed from binutils, and is deprecated upstream.
+# (and available as "binutils-gold" which is also a virtual on bookworm so we can reasonably be explicit everywhere)
+	dpkgArch="$(dpkg --print-architecture)"; \
+	if [ "$dpkgArch" = 'arm64' ]; then \
+		apt-get install -y --no-install-recommends binutils-gold; \
+	fi; \
 	rm -rf /var/lib/apt/lists/*
 
 ENV GOLANG_VERSION 1.25.0

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -225,6 +225,16 @@ RUN set -eux; \
 		make \
 		pkg-config \
 	; \
+# go depends on "gold" explicitly on arm64
+# https://github.com/docker-library/golang/issues/570 (go depends on "gold" explicitly on arm64)
+# https://github.com/golang/go/issues/22040
+# ... and as of trixie, "gold" is removed from the "binutils" package:
+# > WARNING: gold is being removed from binutils, and is deprecated upstream.
+# (and available as "binutils-gold" which is also a virtual on bookworm so we can reasonably be explicit everywhere)
+	dpkgArch="$(dpkg --print-architecture)"; \
+	if [ "$dpkgArch" = 'arm64' ]; then \
+		apt-get install -y --no-install-recommends binutils-gold; \
+	fi; \
 	rm -rf /var/lib/apt/lists/*
 {{ ) end -}}
 

--- a/tip/bookworm/Dockerfile
+++ b/tip/bookworm/Dockerfile
@@ -119,6 +119,16 @@ RUN set -eux; \
 		make \
 		pkg-config \
 	; \
+# go depends on "gold" explicitly on arm64
+# https://github.com/docker-library/golang/issues/570 (go depends on "gold" explicitly on arm64)
+# https://github.com/golang/go/issues/22040
+# ... and as of trixie, "gold" is removed from the "binutils" package:
+# > WARNING: gold is being removed from binutils, and is deprecated upstream.
+# (and available as "binutils-gold" which is also a virtual on bookworm so we can reasonably be explicit everywhere)
+	dpkgArch="$(dpkg --print-architecture)"; \
+	if [ "$dpkgArch" = 'arm64' ]; then \
+		apt-get install -y --no-install-recommends binutils-gold; \
+	fi; \
 	rm -rf /var/lib/apt/lists/*
 
 # don't auto-upgrade the gotoolchain

--- a/tip/trixie/Dockerfile
+++ b/tip/trixie/Dockerfile
@@ -119,6 +119,16 @@ RUN set -eux; \
 		make \
 		pkg-config \
 	; \
+# go depends on "gold" explicitly on arm64
+# https://github.com/docker-library/golang/issues/570 (go depends on "gold" explicitly on arm64)
+# https://github.com/golang/go/issues/22040
+# ... and as of trixie, "gold" is removed from the "binutils" package:
+# > WARNING: gold is being removed from binutils, and is deprecated upstream.
+# (and available as "binutils-gold" which is also a virtual on bookworm so we can reasonably be explicit everywhere)
+	dpkgArch="$(dpkg --print-architecture)"; \
+	if [ "$dpkgArch" = 'arm64' ]; then \
+		apt-get install -y --no-install-recommends binutils-gold; \
+	fi; \
 	rm -rf /var/lib/apt/lists/*
 
 # don't auto-upgrade the gotoolchain


### PR DESCRIPTION
- Fixes https://github.com/docker-library/golang/issues/570
- https://github.com/golang/go/issues/22040

> WARNING: gold is being removed from binutils, and is deprecated upstream.