### PR TITLE
Add Alpine 3.24 and drop 3.22

### DIFF
--- a/1.25/alpine3.24/Dockerfile
+++ b/1.25/alpine3.24/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.22 AS build
+FROM alpine:3.24 AS build
 
 ENV PATH /usr/local/go/bin:$PATH
 
@@ -110,7 +110,7 @@ RUN set -eux; \
 	[ "$SOURCE_DATE_EPOCH" = "$epoch" ]; \
 	find /target -newer /target/usr/local/go -exec sh -c 'ls -ld "$@" && exit "$#"' -- '{}' +
 
-FROM alpine:3.22
+FROM alpine:3.24
 
 RUN apk add --no-cache ca-certificates
 

--- a/1.26/alpine3.24/Dockerfile
+++ b/1.26/alpine3.24/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.22 AS build
+FROM alpine:3.24 AS build
 
 ENV PATH /usr/local/go/bin:$PATH
 
@@ -110,7 +110,7 @@ RUN set -eux; \
 	[ "$SOURCE_DATE_EPOCH" = "$epoch" ]; \
 	find /target -newer /target/usr/local/go -exec sh -c 'ls -ld "$@" && exit "$#"' -- '{}' +
 
-FROM alpine:3.22
+FROM alpine:3.24
 
 RUN apk add --no-cache ca-certificates
 

--- a/tip/alpine3.24/Dockerfile
+++ b/tip/alpine3.24/Dockerfile
@@ -4,11 +4,11 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.22 AS build
+FROM alpine:3.24 AS build
 
 ENV PATH /usr/local/go/bin:$PATH
 
-COPY --from=golang:alpine3.22 /usr/local/go /usr/local/goroot-bootstrap
+COPY --from=golang:alpine3.24 /usr/local/go /usr/local/goroot-bootstrap
 
 # tip-20260606: https://github.com/golang/go/tree/d00c67f297ef6f2cb2cd0e9aae59fa3936bb7eca
 ARG GOLANG_COMMIT='d00c67f297ef6f2cb2cd0e9aae59fa3936bb7eca'
@@ -110,7 +110,7 @@ RUN set -eux; \
 	[ "$SOURCE_DATE_EPOCH" = "$epoch" ]; \
 	find /target -newer /target/usr/local/go -exec sh -c 'ls -ld "$@" && exit "$#"' -- '{}' +
 
-FROM alpine:3.22
+FROM alpine:3.24
 
 RUN apk add --no-cache ca-certificates
 

--- a/versions.json
+++ b/versions.json
@@ -385,8 +385,8 @@
     "variants": [
       "trixie",
       "bookworm",
+      "alpine3.24",
       "alpine3.23",
-      "alpine3.22",
       "windows/windowsservercore-ltsc2025",
       "windows/windowsservercore-ltsc2022",
       "windows/nanoserver-ltsc2025",
@@ -788,8 +788,8 @@
     "variants": [
       "trixie",
       "bookworm",
+      "alpine3.24",
       "alpine3.23",
-      "alpine3.22",
       "windows/windowsservercore-ltsc2025",
       "windows/windowsservercore-ltsc2022",
       "windows/nanoserver-ltsc2025",
@@ -894,8 +894,8 @@
     "variants": [
       "trixie",
       "bookworm",
-      "alpine3.23",
-      "alpine3.22"
+      "alpine3.24",
+      "alpine3.23"
     ]
   }
 }

--- a/versions.sh
+++ b/versions.sh
@@ -238,8 +238,8 @@ for version in "${versions[@]}"; do
 			"trixie",
 			"bookworm",
 			(
+				"3.24",
 				"3.23",
-				"3.22",
 				empty
 			| "alpine" + .),
 			if .arches | has("windows-amd64") and .["windows-amd64"].url then # TODO consider windows + tip


### PR DESCRIPTION
Modelled after #577.

This PR updates Alpine to the latest stable version: 3.24.

See also https://alpinelinux.org/posts/Alpine-3.24.0-released.html.